### PR TITLE
Adding the option to disable disabling ports 2&3 when going into self po...

### DIFF
--- a/arch/arm/mach-exynos/mach-hkdk4412.c
+++ b/arch/arm/mach-exynos/mach-hkdk4412.c
@@ -892,8 +892,8 @@ static struct i2c_board_info hkdk4412_i2c_devs7[] __initdata = {
 	/* nothing here yet */
 };
 
-// Disable
-#if 0
+
+#if defined(CONFIG_ODROID_X_LINUX_LEDS)
 static struct gpio_led hkdk4412_gpio_leds[] = {
 	{
 		.name		= "led1",	/* D5 on ODROID-X */
@@ -1096,10 +1096,11 @@ static struct platform_device *hkdk4412_devices[] __initdata = {
 #endif
 	&exynos4_device_ohci,
 	&exynos4_device_dwmci,
+#if defined(CONFIG_ODROID_X_LINUX_LEDS)
 	
 	// Disable : ADD
-	// &hkdk4412_leds_gpio,
-	
+	&hkdk4412_leds_gpio,
+#endif	
 #if defined(CONFIG_LCD_LP101WH1)
 	&hkdk4412_lcd_lp101wh1,
 #endif
@@ -1139,7 +1140,7 @@ static struct i2c_board_info hdmiphy_info = {
 	I2C_BOARD_INFO("hdmiphy-exynos4412", 0x38),
 };
 #endif
-
+if defined(CONFIG_ODROID_X_ANDROID_LEDS)
 //------------------ ADD Hardkernel -------------------
 #include <linux/hrtimer.h>
 #include <linux/slab.h>
@@ -1192,7 +1193,7 @@ static void hkdk4412_led_deinit(void)
 }
 
 //------------------ END Hardkernel -------------------
-
+#endif
 static void __init hkdk4412_gpio_init(void)
 {
 	/* Peripheral power enable (P3V3) */
@@ -1221,10 +1222,12 @@ static void hkdk4412_power_off(void)
 {
 	pr_emerg("Bye...\n");
 
+#if defined(CONFIG_ODROID_X_ANDROID_LEDS)
+
     // ADD Hardkernel
     hkdk4412_led_deinit();
     // END Hardkernel
-
+#endif
 	writel(0x5200, S5P_PS_HOLD_CONTROL);
 	while (1) {
 		pr_emerg("%s : should not reach here!\n", __func__);
@@ -1235,11 +1238,12 @@ static void hkdk4412_power_off(void)
 static void __init hkdk4412_machine_init(void)
 {
 	hkdk4412_gpio_init();
+#if defined(CONFIG_ODROID_X_ANDROID_LEDS)
 
     // ADD Hardkernel
     hkdk4412_led_init();
     // END Hardkernel
-
+#endif
 	/* Register power off function */
 	pm_power_off = hkdk4412_power_off;
 

--- a/arch/arm/mach-exynos/mach-hkdk4412.c
+++ b/arch/arm/mach-exynos/mach-hkdk4412.c
@@ -1140,7 +1140,7 @@ static struct i2c_board_info hdmiphy_info = {
 	I2C_BOARD_INFO("hdmiphy-exynos4412", 0x38),
 };
 #endif
-if defined(CONFIG_ODROID_X_ANDROID_LEDS)
+#if defined(CONFIG_ODROID_X_ANDROID_LEDS)
 //------------------ ADD Hardkernel -------------------
 #include <linux/hrtimer.h>
 #include <linux/slab.h>

--- a/drivers/leds/Kconfig
+++ b/drivers/leds/Kconfig
@@ -537,4 +537,25 @@ config LEDS_TRIGGER_TRANSIENT
 	  GPIO/PWM based hardware.
 	  If unsure, say Y.
 
+choice
+        prompt "ODROID-X LED Style"
+        default ODROID_X_ANDROID_LEDS
+	depends on MACH_HKDK4412
+        help
+	  This is to choose between Android style (default on and flashing)
+	  and Linux style (/sys/class/leds/ledX)
+
+config ODROID_X_LINUX_LEDS
+        bool "Linux"
+        help
+          Linux style LEDs, Provides access to /sys/class/leds
+	  default heartbeat on LED1
+
+config ODROID_X_ANDROID_LEDS
+        bool "Android"
+        help
+          Android style LEDs, one always on, one blinking at 1s
+
+endchoice
+
 endif # NEW_LEDS

--- a/drivers/usb/misc/Kconfig
+++ b/drivers/usb/misc/Kconfig
@@ -249,3 +249,10 @@ config USB_HSIC_USB3503
        depends on I2C
        help
          This option enables support for SMSC USB3503 HSIC to USB 2.0 Driver.
+config USB3503_PORTS_SELF_POWER_DISABLED
+	
+	boolean "Enable Ports 2 & 3 to be diabled"
+	depends on USB_HSIC_USB3503
+	help
+	  Say Y here if you want the ports 2 and 3 to be disabled
+	  when the hub goes into self power mode

--- a/drivers/usb/misc/usb3503.c
+++ b/drivers/usb/misc/usb3503.c
@@ -197,8 +197,13 @@ static int usb3503_set_mode(struct usb3503_hubctl *hc, int mode)
 			goto exit;
 		}
 #endif
+
 		/* PDS : Port2,3 Disable For Self Powered Operation */
+
+		err = -1;
+#if defined(CONFIG_USB3503_PORTS_SELF_POWER_DISABLED)
 		err = reg_update(i2c_dev, PDS_REG, (PDS_PORT2 | PDS_PORT3), 1);
+#endif
 		if (err < 0) {
 			pr_err(HUB_TAG "PDS update fail err = %d\n", err);
 			goto exit;


### PR DESCRIPTION
On my previous kernels, this i2c call would error out.  This would allow the 2 USB ports next to the headphone jacks still function.  As we don't really need a low powered mode, I added an option to disable this call with a Kconfig option.
