### PR TITLE
Mali-400 build and usage of SMP code in preemptible code fixes.

### DIFF
--- a/block/blk-core.c
+++ b/block/blk-core.c
@@ -1273,8 +1273,10 @@ get_rq:
 	init_request_from_bio(req, bio);
 
 	if (test_bit(QUEUE_FLAG_SAME_COMP, &q->queue_flags) ||
-	    bio_flagged(bio, BIO_CPU_AFFINE))
-		req->cpu = smp_processor_id();
+	    bio_flagged(bio, BIO_CPU_AFFINE)) {
+		req->cpu = get_cpu();
+		put_cpu();
+	}
 
 	plug = current->plug;
 	if (plug) {

--- a/drivers/media/video/samsung/mali/linux/mali_kernel_linux.c
+++ b/drivers/media/video/samsung/mali/linux/mali_kernel_linux.c
@@ -228,7 +228,7 @@ int mali_driver_init(void)
 	}
 
 	/* print build options */
-	MALI_DEBUG_PRINT(2, ("%s\n", __malidrv_build_info()));
+	/* MALI_DEBUG_PRINT(2, ("%s\n", __malidrv_build_info())); */
 
     return 0;
 }


### PR DESCRIPTION
Mali-400 build fix is needed because we dont use SVN system as ARM does for testing drivers.
SMP code fix is needed when SMP checking is enabled in kernel hacking, without this fix each usage of block devices pullutes console with stacktraces.
