### PR TITLE
Revert "kernel:sched: LOAD_FREQ (4*HZ+61) avoids loadavg Moire"

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -123,7 +123,7 @@ extern void get_avenrun(unsigned long *loads, unsigned long offset, int shift);
 
 #define FSHIFT		11		/* nr of bits of precision */
 #define FIXED_1		(1<<FSHIFT)	/* 1.0 as fixed-point */
-#define LOAD_FREQ	(4*HZ+61)	/* 4.61 sec intervals */
+#define LOAD_FREQ	(5*HZ+1)	/* 5 sec intervals */
 #define EXP_1		1884		/* 1/exp(5sec/1min) as fixed-point */
 #define EXP_5		2014		/* 1/exp(5sec/5min) */
 #define EXP_15		2037		/* 1/exp(5sec/15min) */


### PR DESCRIPTION
This modification just kills loadavg. (Very very high loadavg at boot, and randomly during operation...)

This reverts commit 1a57319844ea26085eab4489f52caaf54ba905d7.
