### PR TITLE
Extended cdc_acm support

### DIFF
--- a/drivers/usb/class/cdc-acm.c
+++ b/drivers/usb/class/cdc-acm.c
@@ -1790,11 +1790,15 @@ static const struct usb_device_id acm_ids[] = {
 	{ USB_DEVICE(0x04d8, 0x000b),
 	.driver_info = NO_DATA_INTERFACE,
 	},
-
+	
 	/* Exclude XMM6260 boot rom (not running modem software yet) */
 	{ USB_DEVICE(0x058b, 0x0041),
 	.driver_info = NOT_REAL_ACM,
 	},
+	
+	/* control interfaces without any protocol set */
+	{ USB_INTERFACE_INFO(USB_CLASS_COMM, USB_CDC_SUBCLASS_ACM,
+		USB_CDC_PROTO_NONE) },
 
 	/* control interfaces with various AT-command sets */
 	{ USB_INTERFACE_INFO(USB_CLASS_COMM, USB_CDC_SUBCLASS_ACM,


### PR DESCRIPTION
Added support for interfaces without any protocol including Arduino devices.
