### PR TITLE
cleanup of cec-specific things.

### DIFF
--- a/README
+++ b/README
@@ -1,26 +1,3 @@
-Summary:
-	Get CEC (tv-remote control over HDMI) working on linux.
-	There are android-kernel sources, which have not made it 
-	to the main linux kernel-tree, so also the hardkernel 
-	linux-tree doesn't have CEC for exynos platforms.
-
-Status:
-	Copied s5p-cec code from all over the internet, mostly from
-		http://dn.odroid.com/Android_Alpha_4.0.3/BSP/
-	Made it compile as module (s5p-cec.ko)
-	Fixed the insmod()/rmmod() stuff. Error handling and resource 
-		free-ing were quite broken.
-
-	Using a modified cec-client, it's possible to observe the
-	tv changing it's inputs, see:
-		https://github.com/vamanea/libcec.git
-	
-TODO: 
-	Cleanup this tree, so it becomes a nice diff upon hardkernel's 3.8 tree
-
-
-================================================================================
-
         Linux kernel release 3.x <http://kernel.org/>
 
 These are the release notes for Linux version 3.  Read them carefully,

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-export CROSS_COMPILE=arm-linux-gnueabihf-
-export ARCH=arm
-
-make M=drivers/media/platform/s5p-tv modules
-scp drivers/media/platform/s5p-tv/s5p-cec.ko root@x2_wifi:/root


### PR DESCRIPTION
I had expected some discussion and further cleanup before the previous PR was accepted.
My bad.

This cleans up two files I had created for cec-specific things.

The big thing remaining is cleaning up the debug prints a bit. It currently isn't too bad though,
and it'll sure help if someone tries this on anything other than an odroid-X2.
