### PR TITLE
Enable USER key in Linux

### DIFF
--- a/arch/arm/mach-exynos/mach-hkdk4412.c
+++ b/arch/arm/mach-exynos/mach-hkdk4412.c
@@ -254,6 +254,15 @@ static struct gpio_keys_button hkdk4412_gpio_keys_tables[] = {
 		.wakeup			= 1,
 		.debounce_interval	= 1,
 	},
+	{
+		.code			= KEY_PROG1,
+		.gpio			= EXYNOS4_GPX2(2),
+		.desc			= "KEY_USER",
+		.type			= EV_KEY,
+		.active_low		= 1,
+		.wakeup			= 1,
+		.debounce_interval	= 1,
+	},
 };
 
 static struct gpio_keys_platform_data hkdk4412_gpio_keys_data = {


### PR DESCRIPTION
Add support for the second SWITCH as a user key.

This patch enables the second switch as a GPIO key to linux.
