### PR TITLE
Enable USBIP support.

### DIFF
--- a/arch/arm/configs/odroidxu_ubuntu_defconfig
+++ b/arch/arm/configs/odroidxu_ubuntu_defconfig
@@ -3126,7 +3126,10 @@ CONFIG_DMA_ENGINE=y
 # Microsoft Hyper-V guest support
 #
 CONFIG_STAGING=y
-# CONFIG_USBIP_CORE is not set
+CONFIG_USBIP_CORE=m
+CONFIG_USBIP_VHCI_HCD=m
+CONFIG_USBIP_HOST=m
+# CONFIG_USBIP_DEBUG is not set
 # CONFIG_W35UND is not set
 # CONFIG_PRISM2_USB is not set
 # CONFIG_ECHO is not set


### PR DESCRIPTION
This is just the kernel support for USBIP.

The usbip userspace package in the Ubuntu repository is obsolete so the latest version will need to be built manually by the user. See https://bugs.launchpad.net/ubuntu/+source/usbip/+bug/898003 for more details.

Thanks,
Vittorio G
