### PR TITLE
Add start_duty threshold to odroid fan driver

### DIFF
--- a/include/linux/platform_data/odroidu2_fan.h
+++ b/include/linux/platform_data/odroidu2_fan.h
@@ -23,6 +23,7 @@ struct odroid_fan_platform_data {
 	unsigned short pwm_periode_ns;
 	unsigned short pwm_duty;
 	unsigned short pwm_start_temp;
+	unsigned short pwm_start_duty;
 };
 
 #endif /* __LINUX_ODROID_FAN_H */


### PR DESCRIPTION
I m very pleased with the current fan driver, but unfortunately my fan needs a little bit more power than the 'duty' of the odroid will provide in the lower current regions. Thus I have expanded the driver to include a 'start_duty' entity, which is very similar to 'start_temp'.

What it actually does is to check whether the duty is below this threshold and in case it is, it will set duty up to this threshold. That means in case the driver wants the fan to work, it does not start with zero, but with the threshold value. Standard would be zero and thus there is no change in behavior. I have also put a line into the new 'start_temp' check, as the 'duty' value didn't get set to zero, when the 'start_temp' threshold kicked in. So what happened was that the 'start_temp' routine set duty to zero, but if you did a 'cat pwm_duty' it still reported the actual calculated threshold. This is odd behavior in my opinion.

I'd be happy if this gets tested and introduced to mainline. Any suggestions where to post this in the forums, mdrjr?

(Please be nice to me, I am not a coder)
