### PR TITLE
Fix for removing symlink in mali400 driver

### DIFF
--- a/drivers/gpu/arm/mali400/ump/Kbuild
+++ b/drivers/gpu/arm/mali400/ump/Kbuild
@@ -21,7 +21,7 @@ $(error No configuration found for config $(CONFIG). Check that arch-$(CONFIG)/c
 else
 # Link arch to the selected arch-config directory
 $(shell [ -L $(src)/arch ] && rm $(src)/arch)
-$(shell ln -sf arch-$(CONFIG) $(src)/arch)
+$(shell ln -sf $(src)/arch-$(CONFIG) $(src)/arch)
 $(shell touch $(src)/arch/config.h)
 endif
 


### PR DESCRIPTION
patch to remove simlink in mali400 driver. Not needed in kernel but caus...es problems if the yocto build toolchain is used.
