### PR TITLE
we don't need +18dB Record Path Digital Gain here

### DIFF
--- a/sound/soc/codecs/max98090_mixer.c
+++ b/sound/soc/codecs/max98090_mixer.c
@@ -41,7 +41,7 @@
 
 #define 	MIC_ADC_GAIN		(3<<4) // +18dB
 #define 	MIC_ADC_VOLUME		(0x03) // 0dB
-#define   	TUNNING_ADC_GAIN    0x30
+#define   	TUNNING_ADC_GAIN    0x03
 
 //----------------------------------------------------------------------------------------
 // playback function


### PR DESCRIPTION
Reduced "Record Path Digital Gain" to 0dB and this fixed high microphone noise on U3.
