### PR TITLE
exynos-drm: add 85.5MHz pixel clock HDMI PHY config for Exynos4412

### DIFF
--- a/drivers/gpu/drm/exynos/exynos_hdmi.c
+++ b/drivers/gpu/drm/exynos/exynos_hdmi.c
@@ -551,6 +551,15 @@ static const struct hdmiphy_config hdmiphy_v14_configs[] = {
 		},
 	},
 	{
+		.pixel_clock = 85500000,
+		.conf = {
+			0x01, 0xd1, 0x24, 0x11, 0x40, 0x40, 0xd0, 0x08,
+			0x84, 0xa0, 0xd6, 0xd8, 0x45, 0xa0, 0xac, 0x80,
+			0x08, 0x80, 0x11, 0x04, 0x02, 0x22, 0x44, 0x86,
+			0x54, 0x90, 0x24, 0x01, 0x00, 0x00, 0x01, 0x80,
+		},
+	},
+	{
 		.pixel_clock = 106500000,
 		.conf = {
 			0x01, 0xd1, 0x2c, 0x12, 0x40, 0x0c, 0x09, 0x08,
@@ -1765,7 +1774,7 @@ static void hdmi_v14_mode_set(struct hdmi_context *hdata,
 	int hcorrect = 0;
 	int vcorrect = 0;
 
-	if ((m->vdisplay == 768 && m->hdisplay == 1024) || (m->vdisplay == 1024 && m->hdisplay == 1280)) {
+	if (m->vdisplay == 768 || m->vdisplay == 1024) {
 		pr_info("exynos-drm: Applying 257px timings hack\n");
 		hcorrect = 257;
 		vcorrect = 1;


### PR DESCRIPTION
Configuration details from Samsung. This enables 1366x768@60Hz,
which also needs the horizontal blanking hack to work around a
mixer bug, which is now generalized to just look at vertical
resolution.

Signed-off-by: Daniel Drake drake@endlessm.com
