### PR TITLE
Misc fixes for ODroid-C1

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -299,10 +299,7 @@ zinstall uinstall install: vmlinux
 	$(Q)$(MAKE) $(build)=$(boot) MACHINE=$(MACHINE) $@
 
 %.dtb: scripts
-	$(Q)$(MAKE) $(build)=$(subst $(wildcard $(srctree)//),,$(subst $(join /,$(subst dtb,dts,$@)),,$(firstword $(wildcard $(srctree)/$(boot)/dts/amlogic/$(subst dtb,dts,$@) $(srctree)/$(CUSTOMER_DIR_NAME)/meson/dt/$(subst dtb,dts,$@))))) \
-	MACHINE=$(MACHINE) \
-	$(subst $(wildcard $(srctree)//),,$(subst .dts,.dtb,$(firstword $(wildcard $(srctree)/$(boot)/dts/amlogic/$(subst dtb,dts,$@) $(srctree)/$(CUSTOMER_DIR_NAME)/meson/dt/$(subst dtb,dts,$@)))))
-	rm  $(firstword $(wildcard $(srctree)/$(boot)/dts/amlogic/$(subst dtb,dts,$@) $(srctree)/$(CUSTOMER_DIR_NAME)/meson/dt/$(subst dtb,dts,$@)))
+	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) $(boot)/dts/$@
 
 dtbs: scripts
 	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) dtbs

--- a/arch/arm/mach-meson8b/thermal.c
+++ b/arch/arm/mach-meson8b/thermal.c
@@ -65,7 +65,7 @@ int get_cpu_temp(void)
 	if(temps->flag){
 		ret=get_adc_sample(6);
 		if(ret>=0){
-			tempa=(10*(ret-temps->adc_efuse))/32+27;
+			tempa=(10000*(ret-temps->adc_efuse))/32+27000;
 			ret=tempa;
 		}
 	}

--- a/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx.c
+++ b/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx.c
@@ -142,7 +142,7 @@ static int force_vout_index = 0;
 static int hdmi_prbs_mode = 0xffff; /* 0xffff=disable; 0=PRBS 11; 1=PRBS 15; 2=PRBS 7; 3=PRBS 31*/
 static int hdmi_480p_force_clk = 0; /* 200, 225, 250, 270 */
 
-static int debug_level = INF;     // 1: error  2: important  3: normal  4: detailed
+static int debug_level = ERR;     // 1 (ERR): error  2 (IMP): important  3 (INF): normal  4 (LOW): verbose  5 (DET): detailed
 
 /*****************************
 *    hdmitx attr management :
@@ -860,7 +860,6 @@ static ssize_t show_support_3d(struct device * dev, struct device_attribute *att
 
 void hdmi_print(int dbg_lvl, const char *fmt, ...)
 {
-    return;
     va_list args;
     if(dbg_lvl == OFF)
         return ;

--- a/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
+++ b/drivers/amlogic/hdmi/hdmi_tx/hdmi_tx_cec.c
@@ -1564,22 +1564,16 @@ static int __init cec_init(void)
     init_waitqueue_head(&hdmitx_device->cec_wait_rx);
     cec_key_init();
     hdmi_print(INF, CEC "CEC init\n");
-    cec_global_info.cec_flag.cec_key_flag = 0; 
-    cec_global_info.cec_flag.cec_fiq_flag = 0;
-    cec_global_info.cec_flag.cec_init_flag = 0;
+
+    memset(&cec_global_info, 0, sizeof(cec_global_info_t));
     
 #if MESON_CPU_TYPE == MESON_CPU_TYPE_MESON6
     hdmi_wr_reg(CEC0_BASE_ADDR+CEC_CLOCK_DIV_H, 0x00 );
     hdmi_wr_reg(CEC0_BASE_ADDR+CEC_CLOCK_DIV_L, 0xf0 );
 #endif
 
-    cec_global_info.cec_rx_msg_buf.rx_write_pos = 0;
-    cec_global_info.cec_rx_msg_buf.rx_read_pos = 0;
     cec_global_info.cec_rx_msg_buf.rx_buf_size = sizeof(cec_global_info.cec_rx_msg_buf.cec_rx_message)/sizeof(cec_global_info.cec_rx_msg_buf.cec_rx_message[0]);
-    memset(cec_global_info.cec_rx_msg_buf.cec_rx_message, 0, sizeof(cec_global_info.cec_rx_msg_buf.cec_rx_message));
 
-    memset(&cec_global_info, 0, sizeof(cec_global_info_t));
-    
     cec_global_info.hdmitx_device = hdmitx_device;
     
     hdmitx_device->task_cec = kthread_run(cec_task, (void*)hdmitx_device, "kthread_cec");

--- a/drivers/amlogic/thermal/amlogic_thermal.c
+++ b/drivers/amlogic/thermal/amlogic_thermal.c
@@ -669,7 +669,7 @@ static int amlogic_get_temp(struct thermal_zone_device *thermal,
     } else if (virtual_thermal_en) {
 	    *temp = aml_cal_virtual_temp(); 
     } else {
-        *temp = 45;                     // fix cpu temperature to 45 if not trimed && disable virtual thermal    
+        *temp = 45000;                  // fix cpu temperature to 45 if not trimed && disable virtual thermal
     }
 #else
 	*temp = (unsigned long)get_cpu_temp();
@@ -865,8 +865,8 @@ static struct amlogic_thermal_platform_data * amlogic_thermal_init_from_dts(stru
 		}
 		descend=get_desend();
 		for (i = 0; i < pdata->temp_trip_count; i++) {
-			printk("temperature=%d on trip point=%d\n",tmp_level[i].temperature,i);
-			pdata->tmp_trip[i].temperature=tmp_level[i].temperature;
+			printk("temperature=%d on trip point=%d\n",tmp_level[i].temperature * 1000,i);
+			pdata->tmp_trip[i].temperature=tmp_level[i].temperature * 1000;
 			printk("fixing high_freq=%d to ",tmp_level[i].cpu_high_freq);
 			tmp_level[i].cpu_high_freq=fix_to_freq(tmp_level[i].cpu_high_freq,descend);
 			pdata->tmp_trip[i].cpu_lower_level=cpufreq_cooling_get_level(0,tmp_level[i].cpu_high_freq);

--- a/drivers/thermal/thermal_core.c
+++ b/drivers/thermal/thermal_core.c
@@ -347,7 +347,7 @@ static void handle_critical_trips(struct thermal_zone_device *tz,
 	if (trip_type == THERMAL_TRIP_CRITICAL) {
 		dev_emerg(&tz->device,
 			  "critical temperature reached(%d C),shutting down\n",
-			  tz->temperature);
+			  tz->temperature / 1000);
 		orderly_poweroff(true);
 	}
 }
@@ -481,14 +481,7 @@ temp_show(struct device *dev, struct device_attribute *attr, char *buf)
 	if (ret)
 		return ret;
 
-#if defined(CONFIG_MACH_MESON8B_ODROIDC)
-        /* Fake workaround to return the temperature
-         * as millidegree Celsius
-         */
-	return sprintf(buf, "%ld\n", temperature * 1000);
-#else
 	return sprintf(buf, "%ld\n", temperature);
-#endif
 }
 
 static ssize_t


### PR DESCRIPTION
1. AML made a change to the kernel make process that made it impossible to "make meson8b_odroidc.dtb". The first patch simply reverts part of that. I haven't done a huge amount of testing of this, so be sure to check your Ubuntu kernel package's compilation process to be sure it will not break it.
2. HDMI-TX was completely silenced, and it made it impossible to enable any debug information without re-compiling the kernel. If we default the debug level to something more reasonable, it has almost the same effect and is changeable at runtime.
3. There is a gaping null pointer reference in the CEC code. Essentially, the `cec_init` function determines the buffer length, and then the `memset` overwrites it with zeroes. Later code tries to use the last index of the buffer length, which is now `-1`, and so it always breaks on the 17th message (or about the 7th button press). This does not fix the state machine issue at ~200 messages. I did however find that restarting my TV resolved that (no need to restart the ODroid).
4. Everything else uses millicelsius for reporting the system temperature. It looks like some hacks were in place to make the thermal zone report in millicelsius, but not the raw sensor. This patch re-configures everything to use millicelsius to begin with, and increases the precision of the reading significantly. The dtb was not modified, and the values therein are still in whole degrees. This will make lm_sensors report the temp correctly, and will also make Kodi report the temp correctly.

Thanks,

--scott
