### PR TITLE
[aml/vh264] Fixed typo in printk message

### DIFF
--- a/drivers/amlogic/amports/vh264.c
+++ b/drivers/amlogic/amports/vh264.c
@@ -1703,7 +1703,7 @@ static s32 vh264_init(void)
     };
 
 	if(!firmwareloaded){
-        printk("start load orignal firmware ...\n");
+        printk("start load original firmware ...\n");
         if (amvdec_loadmc(vh264_mc) < 0) {
             amvdec_disable();
             return -EBUSY;


### PR DESCRIPTION
This is just a little typo fix in `drivers/amlogic/amports/vh264.c`. I really had to fix this `printk` call because it drives me crazy - every single time when I have a look at my `dmesg`. ;-)
