### PR TITLE
HID: Add support for Hanns.G HT231HPB Touchscreen

### DIFF
--- a/drivers/hid/hid-ids.h
+++ b/drivers/hid/hid-ids.h
@@ -792,3 +792,7 @@
 #define USB_VENDOR_ID_FOCALTECH 0x2808
 #define USB_DEVICE_ID_FOCALTECH_TOUCH   0x81C9
 #endif
+
+/* Silicon Integrated Systems Corp */
+#define USB_VENDOR_ID_SILICON     0x0457
+#define USB_DEVICE_ID_SILICON_TOUCH     0x1057

--- a/drivers/hid/hid-multitouch.c
+++ b/drivers/hid/hid-multitouch.c
@@ -1177,6 +1177,11 @@ static const struct hid_device_id mt_devices[] = {
 		HID_USB_DEVICE(USB_VENDOR_ID_ZYTRONIC,
 			USB_DEVICE_ID_ZYTRONIC_ZXY100) },
 
+	 /* Silicon Integrated Systems Corp */
+  	{ .driver_data = MT_CLS_DEFAULT,
+        HID_USB_DEVICE(USB_VENDOR_ID_SILICON,
+            USB_DEVICE_ID_SILICON_TOUCH) },
+
 	{ }
 };
 MODULE_DEVICE_TABLE(hid, mt_devices);


### PR DESCRIPTION
Added Touchscreen definition in drivers/hid/hid-ids.h
/\* Silicon Integrated Systems Corp */
# define USB_VENDOR_ID_SILICON     0x0457
# define USB_DEVICE_ID_SILICON_TOUCH     0x1057

Added Touchscreen definition in drivers/hid/hid-multitouch.c
 /\* Silicon Integrated Systems Corp */
    { .driver_data = MT_CLS_DEFAULT,
        HID_USB_DEVICE(USB_VENDOR_ID_SILICON,
            USB_DEVICE_ID_SILICON_TOUCH) },
