### PR TITLE
Revert "Update hid-multitouch.c"

### DIFF
--- a/drivers/hid/hid-multitouch.c
+++ b/drivers/hid/hid-multitouch.c
@@ -1074,13 +1074,7 @@ static const struct hid_device_id mt_devices[] = {
     { .driver_data = MT_CLS_DEFAULT,
     	HID_USB_DEVICE(USB_VENDOR_ID_FOCALTECH, 
     	    USB_DEVICE_ID_FOCALTECH_TOUCH) },
-    	    
-   /* Chalkboard Electronics 7" and 10" */
-    { .driver_data = MT_CLS_DEFAULT, HID_USB_DEVICE(USB_VENDOR_ID_MICROCHIP,USB_DEVICE_ID_CHALK_ELEC_7_10) },
 
-    /* Chalkboard Electronics 14" */
-    { .driver_data = MT_CLS_DEFAULT, HID_USB_DEVICE(USB_VENDOR_ID_DWAV,USB_DEVICE_ID_CHALK_ELEC_14) },
-    
     /* Elitegroup Computer Systems */
     { .driver_data = MT_CLS_DEFAULT,
     	HID_USB_DEVICE(USB_VENDOR_ID_ELITEGROUP, 


### PR DESCRIPTION
Reverts hardkernel/linux#65

drivers/hid/hid-multitouch.c:1079:38: error: 'USB_DEVICE_ID_CHALK_ELEC_7_10' undeclared here (not in a function)
drivers/hid/hid-multitouch.c:1082:38: error: 'USB_DEVICE_ID_CHALK_ELEC_14' undeclared here (not in a function)
