### PR TITLE
Additional AUFS fixes for odroidc-3.10.y

### DIFF
--- a/fs/aufs/debug.c
+++ b/fs/aufs/debug.c
@@ -156,7 +156,7 @@ void au_dpri_dalias(struct inode *inode)
 	struct dentry *d;
 
 	spin_lock(&inode->i_lock);
-	hlist_for_each_entry(d, &inode->i_dentry, d_alias)
+	hlist_for_each_entry(d, &inode->i_dentry, d_u.d_alias)
 		au_dpri_dentry(d);
 	spin_unlock(&inode->i_lock);
 }

--- a/fs/aufs/hnotify.c
+++ b/fs/aufs/hnotify.c
@@ -198,7 +198,7 @@ static int hn_gen_by_inode(char *name, unsigned int nlen, struct inode *inode,
 		AuDebugOn(!name);
 		au_iigen_dec(inode);
 		spin_lock(&inode->i_lock);
-		hlist_for_each_entry(d, &inode->i_dentry, d_alias) {
+		hlist_for_each_entry(d, &inode->i_dentry, d_u.d_alias) {
 			spin_lock(&d->d_lock);
 			dname = &d->d_name;
 			if (dname->len != nlen


### PR DESCRIPTION
This fixes a couple other areas where naming changed.
