### PR TITLE
Fix r5p0 fbdev Mali driver

### DIFF
--- a/arch/arm/plat-samsung/devs.c
+++ b/arch/arm/plat-samsung/devs.c
@@ -309,6 +309,8 @@ struct platform_device s5p_device_jpeg = {
 /* FIMD0 */
 static struct mali_gpu_device_data mali_gpu_data = {
         .shared_mem_size = 256*1024*1024,
+        .fb_start = 0x67900000,
+        .fb_size = 0x01800000,
 };
 
 static struct resource mali_gpu_resource[] = {


### PR DESCRIPTION
Fixes the black screen with the r5p0 fbdev driver, 

https://github.com/hardkernel/linux/commit/db41cd1bc39140d6893c382d3e358b68551a24a1

Thanks to Owersun

http://forum.odroid.com/viewtopic.php?f=9&t=10919
