### PR TITLE
Fixes mmc_spi on C1

### DIFF
--- a/arch/arm/boot/dts/meson8b_odroidc.dts
+++ b/arch/arm/boot/dts/meson8b_odroidc.dts
@@ -504,6 +504,13 @@
         num_chipselect = <2>;
         cs_gpios = "GPIOX_20", "GPIOX_21";
 
+        mmc-slot@0 {
+            compatible = "mmc-spi-slot";
+            reg = <0x0>;
+            spi-max-frequency = <2000000>;
+            voltage-ranges = <3300 3300>;
+        };
+
         spidev@0 {
             spi-max-frequency = <2000000>;
             compatible = "spidev";

--- a/drivers/mmc/card/block.c
+++ b/drivers/mmc/card/block.c
@@ -133,6 +133,10 @@ enum {
 	MMC_PACKED_NR_SINGLE,
 };
 
+#if defined(CONFIG_MACH_MESON8B_ODROIDC)
+#define	AML_SDHC_RESERVED_IDX	0
+#endif
+
 module_param(perdev_minors, int, 0444);
 MODULE_PARM_DESC(perdev_minors, "Minors numbers to allocate per device");
 
@@ -2205,25 +2209,16 @@ static struct mmc_blk_data *mmc_blk_alloc_req(struct mmc_card *card,
 	 */
 #if defined(CONFIG_MACH_MESON8B_ODROIDC)
     if (strncmp(dev_name(mmc_dev(card->host)), "aml_sdhc.0", 8) == 0) {
-        md->name_idx = 0;
-        __set_bit(md->name_idx, name_use);
-    } else if (strncmp(dev_name(mmc_dev(card->host)), "aml_sdio.0", 8) == 0) {
-        if (!subname) {
-            md->name_idx = find_first_zero_bit(name_use, max_devices);
-            __set_bit(md->name_idx, name_use);
-        } else {
-            md->name_idx = ((struct mmc_blk_data *)
-                            dev_to_disk(parent)->private_data)->name_idx;
-        }
-    }
-#else
+        md->name_idx = AML_SDHC_RESERVED_IDX;
+    } else
+#endif
 	if (!subname) {
 		md->name_idx = find_first_zero_bit(name_use, max_devices);
 		__set_bit(md->name_idx, name_use);
 	} else
 		md->name_idx = ((struct mmc_blk_data *)
 				dev_to_disk(parent)->private_data)->name_idx;
-#endif
+
 	md->area_type = area_type;
 
 	/*
@@ -2659,6 +2654,10 @@ static struct mmc_driver mmc_driver = {
 static int __init mmc_blk_init(void)
 {
 	int res;
+
+#if defined(CONFIG_MACH_MESON8B_ODROIDC)
+	__set_bit(AML_SDHC_RESERVED_IDX, name_use);
+#endif
 
 	if (perdev_minors != CONFIG_MMC_BLOCK_MINORS)
 		pr_info("mmcblk: using %d minors per device\n", perdev_minors);

--- a/drivers/mmc/host/mmc_spi.c
+++ b/drivers/mmc/host/mmc_spi.c
@@ -153,6 +153,7 @@ struct mmc_spi_host {
 	dma_addr_t		ones_dma;
 };
 
+static struct mmc_claim mmc_spi_claim;
 
 /****************************************************************************/
 
@@ -1365,6 +1366,9 @@ static int mmc_spi_probe(struct spi_device *spi)
 	if (!mmc)
 		goto nomem;
 
+	spin_lock_init(&mmc_spi_claim.lock);
+	init_waitqueue_head(&mmc_spi_claim.wq);
+	mmc->alldev_claim = &mmc_spi_claim;
 	mmc->ops = &mmc_spi_ops;
 	mmc->max_blk_size = MMC_SPI_BLOCKSIZE;
 	mmc->max_segs = MMC_SPI_BLOCKSATONCE;


### PR DESCRIPTION
Tested with a SD card shield and a 16 GB SD card:

> [  223.403814@3] spicc spicc: SPICC init ok
> [  233.007542@0] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 2000000, spi->chip_select = 0, spi->mode = 0x00
> [  233.022360@0] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 2000000, spi->chip_select = 0, spi->mode = 0x04
> [  233.022474@0] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 2000000, spi->chip_select = 0, spi->mode = 0x00
> [  233.022495@0] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.042138@0] mmc_spi spi0.0: SD/MMC host mmc2, no DMA, no WP, no poweroff, cd polling
> [  233.042189@3] mmc2: mmc_rescan_try_freq: trying to init card at 400000 Hz
> [  233.043404@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.044434@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.213603@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.214048@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.215282@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.216630@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.218799@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 400000, spi->chip_select = 0, spi->mode = 0x00
> [  233.219321@3] mmc2: host does not support reading read-only switch. assuming write-enable.
> [  233.219346@3] mmc_spi spi0.0: spicc_setup : spi->bits_per_word = 8, spi->max_spped_hz = 2000000, spi->chip_select = 0, spi->mode = 0x00
> [  233.219358@3] mmc2: new SDHC card on SPI
> [  233.219796@3] mmcblk1: mmc2:0000 SL16G 14.8 GiB 
> [  233.245832@3]  mmcblk1: p1 p2
> 
> root@odroid:/mnt# mount
> /dev/mmcblk0p2 on / type ext4 (rw,noatime,nodiratime,errors=remount-ro)
> proc on /proc type proc (rw,noexec,nosuid,nodev)
> none on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,noexec,nosuid,nodev)
> sysfs on /sys type sysfs (rw,noexec,nosuid,nodev)
> none on /sys/fs/cgroup type tmpfs (rw)
> none on /sys/kernel/debug type debugfs (rw)
> none on /sys/kernel/security type securityfs (rw)
> udev on /dev type devtmpfs (rw,mode=0755)
> devpts on /dev/pts type devpts (rw,noexec,nosuid,gid=5,mode=0620)
> tmpfs on /tmp type tmpfs (rw,nosuid,nodev,mode=1777)
> tmpfs on /run type tmpfs (rw,noexec,nosuid,size=10%,mode=0755)
> none on /run/lock type tmpfs (rw,noexec,nosuid,nodev,size=5242880)
> none on /run/shm type tmpfs (rw,nosuid,nodev)
> none on /run/user type tmpfs (rw,noexec,nosuid,nodev,size=104857600,mode=0755)
> systemd on /sys/fs/cgroup/systemd type cgroup (rw,noexec,nosuid,nodev,none,name=systemd)
> gvfsd-fuse on /run/user/1001/gvfs type fuse.gvfsd-fuse (rw,nosuid,nodev,user=odroid)
> /dev/mmcblk1p1 on /mnt type vfat (ro)
