### PR TITLE
ODROID-XU3/XU4: Enable PWM output for status LEDs in dts under 4.2rc1

### DIFF
--- a/arch/arm/boot/dts/exynos5422-odroidxu3-common.dtsi
+++ b/arch/arm/boot/dts/exynos5422-odroidxu3-common.dtsi
@@ -471,7 +471,7 @@
 	 */
 	pinctrl-0 = <&pwm0_out &pwm1_out &pwm2_out &pwm3_out>;
 	pinctrl-names = "default";
-	samsung,pwm-outputs = <0>;
+	samsung,pwm-outputs = <0>, <1>, <2>, <3>;
 	status = "okay";
 };
 

--- a/arch/arm/boot/dts/exynos5422-odroidxu4.dts
+++ b/arch/arm/boot/dts/exynos5422-odroidxu4.dts
@@ -21,6 +21,10 @@
 	pwmleds {
 		/delete-node/ greenled;
 	};
+
+	gpioleds {
+		/delete-node/ redled;
+	};
 };
 
 &usbdrd_dwc3_1 {

--- a/arch/arm/boot/dts/exynos5422-odroidxu4.dts
+++ b/arch/arm/boot/dts/exynos5422-odroidxu4.dts
@@ -17,6 +17,10 @@
 / {
 	model = "Hardkernel Odroid XU4";
 	compatible = "hardkernel,odroid-xu4", "samsung,exynos5800", "samsung,exynos5";
+
+	pwmleds {
+		/delete-node/ greenled;
+	};
 };
 
 &usbdrd_dwc3_1 {


### PR DESCRIPTION
PWM setup for blue status LED on XU4 fails with "tried to request PWM channel 1 without output" in dmesg under 4.2rc1 and therefore no heart beat is shown.
Add further PWM outputs to dts to fix this.

This dts extension fixes the blue status LED on my XU4 however I'm no DT expert and would appreciate a review.
