### PR TITLE
ODROID-XU4: Enable TUN module

### DIFF
--- a/arch/arm/configs/odroidxu4_defconfig
+++ b/arch/arm/configs/odroidxu4_defconfig
@@ -1099,7 +1099,7 @@ CONFIG_NET_CORE=y
 # CONFIG_NETCONSOLE is not set
 # CONFIG_NETPOLL is not set
 # CONFIG_NET_POLL_CONTROLLER is not set
-# CONFIG_TUN is not set
+CONFIG_TUN=m
 # CONFIG_TUN_VNET_CROSS_LE is not set
 # CONFIG_VETH is not set
 # CONFIG_NLMON is not set


### PR DESCRIPTION
Enable TUN device module, needed by openvpn, etc.
