### PR TITLE
rtl8812au: Add support for Edimax EW-7811UTC USB dongle

### DIFF
--- a/backports/drivers/realtek/rtl8812au/os_dep/linux/usb_intf.c
+++ b/backports/drivers/realtek/rtl8812au/os_dep/linux/usb_intf.c
@@ -302,6 +302,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x13b1, 0x003f),.driver_info = RTL8812}, /* Linksys WUSB6300 */
 	{USB_DEVICE(0x20f4, 0x805b),.driver_info = RTL8812}, /* TRENDnet - */
 	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - Archer T4U */
+        {USB_DEVICE(0x7392, 0xA812),.driver_info = RTL8812}, /* Edimax - Edimax */
 	{USB_DEVICE(0x7392, 0xA813),.driver_info = RTL8812}, /* Edimax - Edimax 2 */
 #endif
 


### PR DESCRIPTION
Tested on ODROID-C1+ and Edimax dongle idVendor=7392, idProduct=a812
