### PR TITLE
Fix/Improve Hardware RNG for ODROID C1

### DIFF
--- a/drivers/char/hw_random/meson-rng.c
+++ b/drivers/char/hw_random/meson-rng.c
@@ -72,6 +72,28 @@ static int meson_read(struct hwrng *rng, void *buf,
 	return 8;
 }
 
+static int meson_rng_init(struct hwrng *rng)
+{
+	print_state("b resu");
+	switch_mod_gate_by_type(MOD_RANDOM_NUM_GEN, 1);
+	print_state("a resu");
+
+	// Enable the ring oscillator
+	// NOTE:  CBUS 0x207f bit[0] = enable
+	// NOTE:  CBUS 0x207f bit[1] = high-frequency mode.
+	//      Setting bit[1]=1 may change the randomness even more
+	aml_set_reg32_mask(P_AM_RING_OSC_REG0, (1 << 0) | (1 << 1));
+
+	return 0;
+}
+
+static void meson_rng_cleanup(struct hwrng *rng)
+{
+	print_state("b susp");
+	switch_mod_gate_by_type(MOD_RANDOM_NUM_GEN, 0);
+	print_state("a susp");
+}
+
 static int meson_rng_probe(struct platform_device *pdev)
 {
 	struct meson_rng *meson_rng;
@@ -107,24 +129,17 @@ static int meson_rng_remove(struct platform_device *pdev)
 #if defined(CONFIG_PM_SLEEP) || defined(CONFIG_PM_RUNTIME)
 static int meson_rng_runtime_suspend(struct device *dev)
 {
-	print_state("b susp");
-	switch_mod_gate_by_type(MOD_RANDOM_NUM_GEN, 0);
-	print_state("a susp");
+	struct platform_device *pdev = to_platform_device(dev);
+	struct meson_rng *meson_rng = platform_get_drvdata(pdev);
+	meson_rng_cleanup(&meson_rng->rng);
 	return 0;
 }
 
 static int meson_rng_runtime_resume(struct device *dev)
 {
-	print_state("b resu");
-	switch_mod_gate_by_type(MOD_RANDOM_NUM_GEN, 1);
-	print_state("a resu");
-
-	// Enable the ring oscillator
-	// NOTE:  CBUS 0x207f bit[0] = enable
-	// NOTE:  CBUS 0x207f bit[1] = high-frequency mode.
-	//      Setting bit[1]=1 may change the randomness even more
-	aml_set_reg32_mask(P_AM_RING_OSC_REG0, (1 << 0) | (1 << 1));
-
+	struct platform_device *pdev = to_platform_device(dev);
+	struct meson_rng *meson_rng = platform_get_drvdata(pdev);
+	meson_rng_init(&meson_rng->rng);
 	return 0;
 }
 #endif

--- a/drivers/char/hw_random/meson-rng.c
+++ b/drivers/char/hw_random/meson-rng.c
@@ -105,6 +105,8 @@ static int meson_rng_probe(struct platform_device *pdev)
 
 	meson_rng->dev = &pdev->dev;
 	meson_rng->rng.name = "meson";
+	meson_rng->rng.init = meson_rng_init;
+	meson_rng->rng.cleanup = meson_rng_cleanup;
 	meson_rng->rng.read = meson_read;
 
 	platform_set_drvdata(pdev, meson_rng);


### PR DESCRIPTION
Hello

From what I understand, by commiting efa186ddc which disables `CONFIG_PM_RUNTIME`, the init routines for the HW RNG are neither defined nor (obviously) automatically ran by the PM system and therefore entropy validation fails when `rngd` tries to use the device.

On a typical start up of `rngd`, this leads to the following series of messages , as seen on [the forums](http://forum.odroid.com/viewtopic.php?f=117&t=19425), which understandably confuses poor user ctmme.

```
rngd 2-unofficial-mt.14 starting up...
block failed FIPS test: 0x17
block failed FIPS test: 0x17
block failed FIPS test: 0x17
Too many consecutive bad blocks of data, check entropy source!
Throttling down entropy source read speed...
block failed FIPS test: 0x17
block failed FIPS test: 0x17
block failed FIPS test: 0x17
block failed FIPS test: 0x17
block failed FIPS test: 0x17
block failed FIPS test: 0x17
block failed FIPS test: 0x17
```

Eventually it fails and `rngd` will bail out in the usual case.

My pull request is two-fold:
- It extracts the initialization/teardown code to separate functions matching the signature expected by `struct hwrng` callbacks, while keeping the power management code working the same way.
- It sets the initialization and cleanup callback of that struct so the code is called even when CONFIG_PM_RUNTIME is undefined. However I'm not sure the cleanup callback is needed here.

As this is my first kernel patch and I'm in no way familiar with the power management systems, please review thoroughly. In particular I wonder if assigning .cleanup is needed, and I'm not 100% sure the two calls that are added in the resume/suspend functions are side-effect free.

This fixes #157
