### PR TITLE
[amlogic_cec] Fix for stuck messages in read queue Odroid C2

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx_20/amlogic_cec.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/amlogic_cec.c
@@ -458,14 +458,17 @@ static ssize_t amlogic_cec_read(struct file *file, char __user *buffer,
 
     retval = entry->size;
 
-    amlogic_cec_set_rx_state(STATE_RX);
-
 error_exit:
     if (entry != NULL)
     {
         list_del(&entry->list);
         kfree(entry);
     }
+
+    if (list_empty(&cec_rx_struct.list))
+     {
+         amlogic_cec_set_rx_state(STATE_RX);
+     }
 
     spin_unlock_irqrestore(&cec_rx_struct.lock, spin_flags);
 
@@ -560,8 +563,11 @@ static long amlogic_cec_ioctl(struct file *file, unsigned int cmd,
 
 static u32 amlogic_cec_poll(struct file *file, poll_table *wait)
 {
-    poll_wait(file, &cec_rx_struct.waitq, wait);
 
+    if (atomic_read(&cec_rx_struct.state) != STATE_DONE)
+    {
+        poll_wait(file, &cec_rx_struct.waitq, wait);
+    }
     if (atomic_read(&cec_rx_struct.state) == STATE_DONE)
     {
         return POLLIN | POLLRDNORM;


### PR DESCRIPTION
The commit fixes a bug where RX messages got stuck in the read queue.

I've ported the patch from @gdachs:
https://github.com/OpenELEC/OpenELEC.tv/pull/4934
