### PR TITLE
builddeb: add arm64 in the supported architectures

### DIFF
--- a/scripts/package/builddeb
+++ b/scripts/package/builddeb
@@ -42,6 +42,8 @@ create_package() {
 		debarch=hppa ;;
 	mips*)
 		debarch=mips$(grep -q CPU_LITTLE_ENDIAN=y $KCONFIG_CONFIG && echo el || true) ;;
+	arm64)
+		debarch=arm64 ;;
 	arm*)
 		debarch=arm$(grep -q CONFIG_AEABI=y $KCONFIG_CONFIG && echo el || true) ;;
 	*)


### PR DESCRIPTION
Signed-off-by: Fathi Boudra fathi.boudra@linaro.org
Reviewed-by: Ben Hutchings ben@decadent.org.uk
Signed-off-by: Michal Marek mmarek@suse.cz
