### PR TITLE
Kodi Video: fix black screens when playing 23.976/29.97/59.94fps using amcodec decoding.  

### DIFF
--- a/drivers/amlogic/amports/video.c
+++ b/drivers/amlogic/amports/video.c
@@ -4442,6 +4442,8 @@ static void video_vf_light_unreg_provider(void)
 	spin_unlock_irqrestore(&lock, flags);
 }
 
+static int frame_duration = 0;
+
 static int video_receiver_event_fun(int type, void *data, void *private_data)
 {
 #ifdef CONFIG_AM_VIDEO2
@@ -4488,10 +4490,14 @@ static int video_receiver_event_fun(int type, void *data, void *private_data)
 	} else if (type == VFRAME_EVENT_PROVIDER_FR_HINT) {
 #ifdef CONFIG_AM_VOUT
 		if (data != NULL)
-			set_vframe_rate_hint((unsigned long)(data));
+		{
+			frame_duration = (int)data;
+			set_vframe_rate_hint(frame_duration);
+		}
 #endif
 	} else if (type == VFRAME_EVENT_PROVIDER_FR_END_HINT) {
 #ifdef CONFIG_AM_VOUT
+		frame_duration = 0;
 		set_vframe_rate_end_hint();
 #endif
 	}
@@ -6701,6 +6707,8 @@ int vout_notify_callback(struct notifier_block *block, unsigned long cmd,
 		vsync_pts_inc_scale_base = vinfo->sync_duration_num;
 		spin_unlock_irqrestore(&lock, flags);
 		new_vmode = vinfo->mode;
+		if (frame_duration > 0)
+			set_vframe_rate_hint(frame_duration);
 		break;
 	case VOUT_EVENT_OSD_PREBLEND_ENABLE:
 		vpp_set_osd_layer_preblend(para);

--- a/drivers/amlogic/display/vout/tv_vout.c
+++ b/drivers/amlogic/display/vout/tv_vout.c
@@ -757,7 +757,7 @@ static int get_vsource_frame_rate(int duration)
 		break;
 	case 1601:
 	case 1602:
-		frame_rate = 5994;
+		frame_rate = 6000;
 		break;
 	case 1920:
 		frame_rate = 5000;
@@ -766,7 +766,7 @@ static int get_vsource_frame_rate(int duration)
 		frame_rate = 3000;
 		break;
 	case 3203:
-		frame_rate = 2997;
+		frame_rate = 3000;
 		break;
 	case 3840:
 		frame_rate = 2500;
@@ -775,7 +775,7 @@ static int get_vsource_frame_rate(int duration)
 		frame_rate = 2400;
 		break;
 	case 4004:
-		frame_rate = 2397;
+		frame_rate = 2400;
 		break;
 	default:
 		break;


### PR DESCRIPTION
Modify S905 display drivers to fix black screens when dynamic Refresh Switching and playing back Fractional Refresh Rate video using amcodec decoding with Kodi.
Original fix for v3.10 Kernel by Codesnake and modded for v3.14 by Alex (surkovalex), tested extensively by LibreELEC users. 👍 

W. 
