### PR TITLE
Enable bootarg in order to force use of RGB colorspace

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx_14/hdmi_tx.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_14/hdmi_tx.c
@@ -2135,6 +2135,9 @@ static  int __init hdmitx_boot_para_setup(char *s)
 			hdmitx_device.cec_func_config = list;
 		hdmi_print(INF, CEC "HDMI hdmi_cec_func_config:0x%x\n",
 			hdmitx_device.cec_func_config);
+		} else if (strcmp(token, "forcergb") == 0) {
+			hdmitx_output_rgb();
+			hdmi_print(IMP, "Forced RGB colorspace output\n");
 		}
 	}
 		offset = token_offset;

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -2471,6 +2471,9 @@ static  int __init hdmitx_boot_para_setup(char *s)
 				hdmitx_device.cec_func_config = list;
 			hdmi_print(INF, CEC "HDMI hdmi_cec_func_config:0x%x\n",
 				   hdmitx_device.cec_func_config);
+		} else if (strcmp(token, "forcergb") == 0) {
+			hdmitx_output_rgb();
+			hdmi_print(IMP, "Forced RGB colorspace output\n");
 		}
 	}
 		offset = token_offset;


### PR DESCRIPTION
Some old TVs (tested with Philips) report incorrectly HDMI requests to change colorspace.
The result is an image flooded with green/magenta colors.

This workaround enables a bootarg hdmitx=forcergb in order to ignore the HDMI request
from the TV and use always RGB colorspace. I've only created the bootarg because
the source code to force the colorspace was already there but surprisingly was not being used.
