### PR TITLE
Fix Odroid C2 watchdog timeout problems

### DIFF
--- a/arch/arm64/boot/dts/amlogic/mesongxbb.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesongxbb.dtsi
@@ -298,13 +298,12 @@
 
 	amlwatchdog: amlogic-watchdog{
 		compatible = "amlogic, gx-wdt";
-		status = "disable";
-		default_timeout = <10>;
+		default_timeout = <25>;
 		reset_watchdog_method = <1>;//0:sysfs,1:kernel
 		reset_watchdog_time = <2>;
-		shutdown_timeout = <10>;
-		firmware_timeout = <6>;
-		suspend_timeout = <6>;
+		shutdown_timeout = <30>;
+		firmware_timeout = <20>;
+		suspend_timeout = <20>;
 		reg = <0x0 0xc11098d0 0x0 0x10>;
 		clocks = <&clock CLK_XTAL>;
 	};


### PR DESCRIPTION
Now, I'm not saying you merge this - please don't without some scrutiny - but this change fixed a reboot loop for me.

I increased the timings on the watchdog and removed the disabled line.

I'm not sure which of these 2 things fixed the problem, but it did. And it might be worth thinking about this. It was a bit difficult to find this as the cause of the boot loop, but it makes sense.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hardkernel/linux/211)

<!-- Reviewable:end -->
