### PR TITLE
Fallback to a "sane" speed

### DIFF
--- a/drivers/gpu/drm/exynos/exynos_dp_core.c
+++ b/drivers/gpu/drm/exynos/exynos_dp_core.c
@@ -672,7 +672,7 @@ static void exynos_dp_init_training(struct exynos_dp_device *dp,
 	if ((dp->link_train.link_rate != LINK_RATE_1_62GBPS) &&
 	   (dp->link_train.link_rate != LINK_RATE_2_70GBPS)) {
 		if (dp->link_train.link_rate == LINK_RATE_5_40GBPS) {
-			dev_err(dp->dev, "Rx Max Link Rate 5.4GBPS is too high, fallback to half!\n")
+			dev_err(dp->dev, "Rx Max Link Rate 5.4GBPS is too high, fallback to 2.7GBPS!\n");
 			dp->link_train.link_rate = LINK_RATE_2_70GBPS;
 		} else {
 			dev_err(dp->dev, "Rx Max Link Rate is abnormal :%x !\n",

--- a/drivers/gpu/drm/exynos/exynos_dp_core.c
+++ b/drivers/gpu/drm/exynos/exynos_dp_core.c
@@ -671,9 +671,14 @@ static void exynos_dp_init_training(struct exynos_dp_device *dp,
 
 	if ((dp->link_train.link_rate != LINK_RATE_1_62GBPS) &&
 	   (dp->link_train.link_rate != LINK_RATE_2_70GBPS)) {
-		dev_err(dp->dev, "Rx Max Link Rate is abnormal :%x !\n",
-			dp->link_train.link_rate);
-		dp->link_train.link_rate = LINK_RATE_1_62GBPS;
+		if (dp->link_train.link_rate == LINK_RATE_5_40GBPS) {
+			dev_err(dp->dev, "Rx Max Link Rate 5.4GBPS is too high, fallback to half!\n")
+			dp->link_train.link_rate = LINK_RATE_2_70GBPS;
+		} else {
+			dev_err(dp->dev, "Rx Max Link Rate is abnormal :%x !\n",
+				dp->link_train.link_rate);
+			dp->link_train.link_rate = LINK_RATE_1_62GBPS;
+		}
 	}
 
 	if (dp->link_train.lane_count == 0) {

--- a/drivers/gpu/drm/exynos/exynos_dp_core.h
+++ b/drivers/gpu/drm/exynos/exynos_dp_core.h
@@ -23,7 +23,8 @@
 
 enum link_rate_type {
 	LINK_RATE_1_62GBPS = 0x06,
-	LINK_RATE_2_70GBPS = 0x0a
+	LINK_RATE_2_70GBPS = 0x0a,
+	LINK_RATE_5_40GBPS = 0x14
 };
 
 enum link_lane_count_type {


### PR DESCRIPTION
DP1.2 allows for speeds of 5.4Gbps/lane (HB2). However the XU3 falls back to 1.62GBPS instead of 2.7GBPS.
Upping the fallback speed to half the max lane speed fixed getting a PLL lock on the monitor.
