### PR TITLE
Fix AUFS support / s_files (for Docker AUFS storage driver support)

### DIFF
--- a/fs/aufs/f_op.c
+++ b/fs/aufs/f_op.c
@@ -35,6 +35,8 @@ int au_do_open_nondir(struct file *file, int flags)
 		au_set_fbstart(file, bindex);
 		au_set_h_fptr(file, bindex, h_file);
 		au_update_figen(file);
+		finfo->fi_file = file;
+		au_sphl_add(&finfo->fi_hlist, &au_sbi(dentry->d_sb)->si_files);
 		/* todo: necessary? */
 		/* file->f_ra = h_file->f_ra; */
 	}
@@ -65,6 +67,7 @@ int aufs_release_nondir(struct inode *inode __maybe_unused, struct file *file)
 	aufs_bindex_t bindex;
 
 	finfo = au_fi(file);
+	au_sphl_del(&finfo->fi_hlist, &au_sbi(file->f_dentry->d_sb)->si_files);
 	bindex = finfo->fi_btop;
 	if (bindex >= 0)
 		au_set_h_fptr(file, bindex, NULL);

--- a/fs/aufs/file.h
+++ b/fs/aufs/file.h
@@ -48,6 +48,8 @@ struct au_finfo {
 		atomic_t			fi_mmapped;
 	};
 	struct au_fidir		*fi_hdir;	/* for dir only */
+	struct hlist_node   fi_hlist;
+	struct file     *fi_file;   /* very ugly */
 } ____cacheline_aligned_in_smp;
 
 /* ---------------------------------------------------------------------- */

--- a/fs/aufs/sbinfo.c
+++ b/fs/aufs/sbinfo.c
@@ -105,6 +105,8 @@ int au_si_alloc(struct super_block *sb)
 	init_waitqueue_head(&sbinfo->si_plink_wq);
 	spin_lock_init(&sbinfo->si_plink_maint_lock);
 
+	au_sphl_init(&sbinfo->si_files);
+
 	/* leave other members for sysaufs and si_mnt. */
 	sbinfo->si_sb = sb;
 	sb->s_fs_info = sbinfo;

--- a/fs/aufs/super.h
+++ b/fs/aufs/super.h
@@ -96,7 +96,8 @@ struct au_sbinfo {
 	} au_si_pid;
 
 	/*
-	 * dirty approach to protect sb->sb_inodes and ->s_files from remount.
+	* dirty approach to protect sb->sb_inodes and ->s_files (gone) from
+	* remount.
 	 */
 	atomic_long_t		si_ninodes, si_nfiles;
 
@@ -176,6 +177,9 @@ struct au_sbinfo {
 	wait_queue_head_t	si_plink_wq;
 	spinlock_t		si_plink_maint_lock;
 	pid_t			si_plink_maint_pid;
+
+	/* file list */
+	struct au_sphlhead  si_files;
 
 	/*
 	 * sysfs and lifetime management.

--- a/fs/aufs/vfsub.h
+++ b/fs/aufs/vfsub.h
@@ -23,37 +23,6 @@ extern struct lglock vfsmount_lock;
 extern void __mnt_drop_write(struct vfsmount *);
 extern spinlock_t inode_sb_list_lock;
 
-/* copied from linux/fs/file_table.c */
-extern struct lglock files_lglock;
-#ifdef CONFIG_SMP
-/*
- * These macros iterate all files on all CPUs for a given superblock.
- * files_lglock must be held globally.
- */
-#define do_file_list_for_each_entry(__sb, __file)		\
-{								\
-	int i;							\
-	for_each_possible_cpu(i) {				\
-		struct list_head *list;				\
-		list = per_cpu_ptr((__sb)->s_files, i);		\
-		list_for_each_entry((__file), list, f_u.fu_list)
-
-#define while_file_list_for_each_entry				\
-	}							\
-}
-
-#else
-
-#define do_file_list_for_each_entry(__sb, __file)		\
-{								\
-	struct list_head *list;					\
-	list = &(sb)->s_files;					\
-	list_for_each_entry((__file), list, f_u.fu_list)
-
-#define while_file_list_for_each_entry				\
-}
-#endif
-
 /* ---------------------------------------------------------------------- */
 
 /* lock subclass for lower inode */


### PR DESCRIPTION
Ported patch from https://sourceforge.net/p/aufs/mailman/message/34266023/
to kernel 3.10.96 due to needed AUFS support in C1 branch.

Tested on Debian Jessie ARMHF with Docker 1.11.1 package. 

Original message :
# 

commit c4f4458
Author: J. R. Okajima hooanon05@...
Date:   Fri Dec 13 15:51:49 2013 +0900

```
aufs: for linux-3.13, s_files is gone and si_files has come

By the commit,
eee5cc2 2013-11-09 get rid of s_files and files_lock
the file list in superblock, s_files is totally removed.

But aufs still needs the file list, particularly for re-setting the
branch attribute from RW to RO.
After resetting to RO, aufs should return EROFS for write. In order to
support such case, aufs keeps the late s_files and mark_files_ro()
approach.
```
# 
