### PR TITLE
Save cec_config for CEC wake-up

### DIFF
--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -737,6 +737,8 @@ static void cec_pre_init(void)
 {
     ao_cec_init();
 
+    cec_config(cec_dev->tx_dev->cec_func_config, 1);
+
     cec_arbit_bit_time_set(3, 0x118, 0);
     cec_arbit_bit_time_set(5, 0x000, 0);
     cec_arbit_bit_time_set(7, 0x2aa, 0);
@@ -1452,8 +1454,6 @@ static int hdmitx_cec_open(struct inode *inode, struct file *file)
     cec_dev->cec_info.open_count++;
     if (cec_dev->cec_info.open_count) {
         cec_dev->cec_info.hal_ctl = 1;
-        /* enable all cec features */
-        cec_config(0x2f, 1);
     }
     return 0;
 }
@@ -1463,8 +1463,6 @@ static int hdmitx_cec_release(struct inode *inode, struct file *file)
     cec_dev->cec_info.open_count--;
     if (!cec_dev->cec_info.open_count) {
         cec_dev->cec_info.hal_ctl = 0;
-        /* disable all cec features */
-        cec_config(0x0, 1);
     }
     return 0;
 }

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -2487,9 +2487,9 @@ static  int __init hdmitx_boot_para_setup(char *s)
 			init_flag |= INIT_FLAG_NOT_LOAD;
 		} else if (strncmp(token, "cec", 3) == 0) {
 			ret = kstrtoul(token+3, 16, &list);
-			if ((list >= 0) && (list <= 0x2f))
+			if ((list >= 0) && (list <= 0xff))
 				hdmitx_device.cec_func_config = list;
-			hdmi_print(INF, CEC "HDMI hdmi_cec_func_config:0x%x\n",
+			hdmi_print(IMP, CEC "HDMI hdmi_cec_func_config:0x%x\n",
 				   hdmitx_device.cec_func_config);
 		} else if (strcmp(token, "forcergb") == 0) {
 			hdmitx_output_rgb();


### PR DESCRIPTION
This saves cec_config for CEC wake-up in bl301/scp_task

Similar patch have already been added to LibreELEC:
https://github.com/LibreELEC/LibreELEC.tv/blob/4841f5f34aa9385a07299bd5005f4d253381a36d/projects/Odroid_C2/patches/linux/linux-006-save-cec-config.patch
