### PR TITLE
Backport of upstream Amlogic patches for Ion and GE2D

### DIFF
--- a/drivers/amlogic/canvas/canvas_mgr.c
+++ b/drivers/amlogic/canvas/canvas_mgr.c
@@ -507,7 +507,7 @@ static void canvas_pool_config(void)
 	canvas_pool_register_const_canvas(0x60, 0x65, "display");
 	canvas_pool_register_const_canvas(0x70, 0x77, "ppmgr");
 	canvas_pool_register_const_canvas(0xe4, 0xec, "encoder");
-	canvas_pool_register_const_canvas(0x40, 0x44, "osd");
+	canvas_pool_register_const_canvas(0x40, 0x48, "osd");
 	canvas_pool_register_const_canvas(0x4e, 0x5f, "vm");
 	/*please add static canvas later. */
 }

--- a/drivers/amlogic/display/ge2d/ge2d_wq.c
+++ b/drivers/amlogic/display/ge2d/ge2d_wq.c
@@ -493,7 +493,7 @@ static void build_ge2d_config(struct config_para_s *cfg,
 			dst->canvas_index = index;
 			canvas_config(index++ & 0xff,
 				      cfg->dst_planes[0].addr,
-				      cfg->dst_planes[0].w * dst->bpp / 8,
+				      cfg->dst_planes[0].w,
 				      cfg->dst_planes[0].h,
 				      CANVAS_ADDR_NOWRAP,
 				      CANVAS_BLKMODE_LINEAR);
@@ -504,7 +504,7 @@ static void build_ge2d_config(struct config_para_s *cfg,
 			dst->canvas_index |= index << 8;
 			canvas_config(index++,
 				      cfg->dst_planes[1].addr,
-				      cfg->dst_planes[1].w * dst->bpp / 8,
+				      cfg->dst_planes[1].w,
 				      cfg->dst_planes[1].h,
 				      CANVAS_ADDR_NOWRAP,
 				      CANVAS_BLKMODE_LINEAR);
@@ -513,7 +513,7 @@ static void build_ge2d_config(struct config_para_s *cfg,
 			dst->canvas_index |= index << 16;
 			canvas_config(index++,
 				      cfg->dst_planes[2].addr,
-				      cfg->dst_planes[2].w * dst->bpp / 8,
+				      cfg->dst_planes[2].w,
 				      cfg->dst_planes[2].h,
 				      CANVAS_ADDR_NOWRAP,
 				      CANVAS_BLKMODE_LINEAR);
@@ -522,7 +522,7 @@ static void build_ge2d_config(struct config_para_s *cfg,
 			dst->canvas_index |= index << 24;
 			canvas_config(index++,
 				      cfg->dst_planes[3].addr,
-				      cfg->dst_planes[3].w * dst->bpp / 8,
+				      cfg->dst_planes[3].w,
 				      cfg->dst_planes[3].h,
 				      CANVAS_ADDR_NOWRAP,
 				      CANVAS_BLKMODE_LINEAR);

--- a/drivers/amlogic/display/ge2d/ge2d_wq.c
+++ b/drivers/amlogic/display/ge2d/ge2d_wq.c
@@ -447,19 +447,36 @@ static void build_ge2d_config(struct config_para_s *cfg,
 
 		if (cfg->src_planes[0].addr) {
 			src->canvas_index = index;
-			canvas_config(index++,
-				      cfg->src_planes[0].addr,
-				      cfg->src_planes[0].w * src->bpp / 8,
-				      cfg->src_planes[0].h,
-				      CANVAS_ADDR_NOWRAP,
-				      CANVAS_BLKMODE_LINEAR);
+
+			if (cfg->src_planes[1].addr ||
+				cfg->src_planes[2].addr ||
+				cfg->src_planes[3].addr)
+			{
+				// Multi plane
+				canvas_config(index++,
+					cfg->src_planes[0].addr,
+					cfg->src_planes[0].w,
+					cfg->src_planes[0].h,
+					CANVAS_ADDR_NOWRAP,
+					CANVAS_BLKMODE_LINEAR);
+			}
+			else
+			{
+				// Single plane
+				canvas_config(index++,
+					cfg->src_planes[0].addr,
+					cfg->src_planes[0].w * src->bpp / 8,
+					cfg->src_planes[0].h,
+					CANVAS_ADDR_NOWRAP,
+					CANVAS_BLKMODE_LINEAR);
+			}
 		}
 		/* multi-src_planes */
 		if (cfg->src_planes[1].addr) {
 			src->canvas_index |= index << 8;
 			canvas_config(index++,
 				      cfg->src_planes[1].addr,
-				      cfg->src_planes[1].w * src->bpp / 8,
+				      cfg->src_planes[1].w,
 				      cfg->src_planes[1].h,
 				      CANVAS_ADDR_NOWRAP,
 				      CANVAS_BLKMODE_LINEAR);
@@ -468,7 +485,7 @@ static void build_ge2d_config(struct config_para_s *cfg,
 			src->canvas_index |= index << 16;
 			canvas_config(index++,
 				      cfg->src_planes[2].addr,
-				      cfg->src_planes[2].w * src->bpp / 8,
+				      cfg->src_planes[2].w,
 				      cfg->src_planes[2].h,
 				      CANVAS_ADDR_NOWRAP,
 				      CANVAS_BLKMODE_LINEAR);
@@ -477,7 +494,7 @@ static void build_ge2d_config(struct config_para_s *cfg,
 			src->canvas_index |= index << 24;
 			canvas_config(index++,
 				      cfg->src_planes[3].addr,
-				      cfg->src_planes[3].w * src->bpp / 8,
+				      cfg->src_planes[3].w,
 				      cfg->src_planes[3].h,
 				      CANVAS_ADDR_NOWRAP,
 				      CANVAS_BLKMODE_LINEAR);
@@ -489,14 +506,32 @@ static void build_ge2d_config(struct config_para_s *cfg,
 		dst->yres = cfg->dst_planes[0].h;
 		dst->ge2d_color_index = cfg->dst_format;
 		dst->bpp = bpp(cfg->dst_format);
+
 		if (cfg->dst_planes[0].addr) {
 			dst->canvas_index = index;
-			canvas_config(index++ & 0xff,
-				      cfg->dst_planes[0].addr,
-				      cfg->dst_planes[0].w,
-				      cfg->dst_planes[0].h,
-				      CANVAS_ADDR_NOWRAP,
-				      CANVAS_BLKMODE_LINEAR);
+
+			if (cfg->dst_planes[1].addr ||
+				cfg->dst_planes[2].addr ||
+				cfg->dst_planes[3].addr)
+			{
+				// Multi plane
+				canvas_config(index++ & 0xff,
+					cfg->dst_planes[0].addr,
+					cfg->dst_planes[0].w,
+					cfg->dst_planes[0].h,
+					CANVAS_ADDR_NOWRAP,
+					CANVAS_BLKMODE_LINEAR);
+			}
+			else
+			{
+				// Single plane
+				canvas_config(index++ & 0xff,
+					cfg->dst_planes[0].addr,
+					cfg->dst_planes[0].w * dst->bpp / 8,
+					cfg->dst_planes[0].h,
+					CANVAS_ADDR_NOWRAP,
+					CANVAS_BLKMODE_LINEAR);
+			}
 		}
 
 		/* multi-src_planes */

--- a/drivers/amlogic/ion_dev/dev_ion.c
+++ b/drivers/amlogic/ion_dev/dev_ion.c
@@ -25,6 +25,8 @@
 #include <linux/of.h>
 #include <linux/of_fdt.h>
 #include <linux/of_reserved_mem.h>
+#include <linux/uaccess.h>
+#include "meson_ion.h"
 
 MODULE_DESCRIPTION("AMLOGIC ION driver");
 MODULE_LICENSE("GPL");
@@ -51,6 +53,92 @@ static struct ion_device *idev;
 static int num_heaps;
 static struct ion_heap **heaps;
 static struct ion_platform_heap my_ion_heap[MAX_HEAP];
+
+struct ion_client *meson_ion_client_create(unsigned int heap_mask,
+	const char *name) {
+
+	/*
+	*	  * The assumption is that if there is a NULL device, the ion
+	*		   * driver has not yet probed.
+	*				*/
+	if (idev == NULL) {
+		dprintk(0, "create error");
+		return ERR_PTR(-EPROBE_DEFER);
+	}
+
+	if (IS_ERR(idev)) {
+		dprintk(0, "idev error");
+		return (struct ion_client *)idev;
+	}
+
+	return ion_client_create(idev, name);
+}
+EXPORT_SYMBOL(meson_ion_client_create);
+
+int meson_ion_share_fd_to_phys(struct ion_client *client,
+	int share_fd, ion_phys_addr_t *addr, size_t *len)
+{
+	struct ion_handle *handle = NULL;
+
+	handle = ion_import_dma_buf(client, share_fd);
+	if (IS_ERR_OR_NULL(handle)) {
+		dprintk(0, "EINVAL, client=%p, share_fd=%d\n",
+			client, share_fd);
+	}
+
+	return ion_phys(client, handle, addr, len);
+}
+EXPORT_SYMBOL(meson_ion_share_fd_to_phys);
+
+static int meson_ion_get_phys(
+	struct ion_client *client,
+	unsigned long arg)
+{
+	struct meson_phys_data data;
+	struct ion_handle *handle;
+	size_t len;
+	ion_phys_addr_t addr;
+	int ret;
+
+	if (copy_from_user(&data, (void __user *)arg,
+		sizeof(struct meson_phys_data))) {
+		return -EFAULT;
+	}
+	handle = ion_import_dma_buf(client, data.handle);
+	if (IS_ERR_OR_NULL(handle)) {
+		dprintk(0, "EINVAL, client=%p, share_fd=%d\n",
+			client, data.handle);
+		return PTR_ERR(handle);
+	}
+
+	ret = ion_phys(client, handle, &addr, (size_t *)&len);
+	dprintk(1, "ret=%d, phys=0x%lX\n", ret, addr);
+	if (ret < 0) {
+		dprintk(0, "meson_ion_get_phys error, ret=%d\n", ret);
+		return ret;
+	}
+	data.phys_addr = (unsigned int)addr;
+	data.size = (unsigned int)len;
+	if (copy_to_user((void __user *)arg, &data,
+		sizeof(struct meson_phys_data))) {
+		return -EFAULT;
+	}
+	return 0;
+}
+
+static long meson_custom_ioctl(
+	struct ion_client *client,
+	unsigned int cmd,
+	unsigned long arg)
+{
+	switch (cmd) {
+		case ION_IOC_MESON_PHYS_ADDR:
+			return meson_ion_get_phys(client, arg);
+		default:
+			return -ENOTTY;
+	}
+	return 0;
+}
 
 int dev_ion_probe(struct platform_device *pdev)
 {
@@ -112,7 +200,8 @@ static int ion_dev_mem_init(struct reserved_mem *rmem, struct device *dev)
 
 	num_heaps++;
 	heaps = kzalloc(sizeof(struct ion_heap *) * num_heaps, GFP_KERNEL);
-	idev = ion_device_create(NULL);
+	/*idev = ion_device_create(NULL);*/
+	idev = ion_device_create(meson_custom_ioctl);
 	if (IS_ERR_OR_NULL(idev)) {
 		kfree(heaps);
 		panic(0);

--- a/drivers/amlogic/ion_dev/meson_ion.h
+++ b/drivers/amlogic/ion_dev/meson_ion.h
@@ -1,0 +1,55 @@
+/*
+ * include/linux/amlogic/dev_ion.h
+ *
+ * Copyright (C) 2014 Amlogic, Inc.
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef __LINUX_AMLOGIC_ION_H__
+#define __LINUX_AMLOGIC_ION_H__
+
+#include <linux/types.h>
+#include <android/ion/ion.h>
+
+/**
+* CUSTOM IOCTL - CMD
+*/
+
+#define ION_IOC_MESON_PHYS_ADDR             8
+
+struct meson_phys_data {
+	int handle;
+	unsigned int phys_addr;
+	unsigned int size;
+};
+
+
+/**
+* meson_ion_client_create() -  allocate a client and returns it
+* @heap_type_mask:	mask of heaps this client can allocate from
+* @name:		used for debugging
+*/
+struct ion_client *meson_ion_client_create(unsigned int heap_mask,
+	const char *name);
+
+/**
+* meson_ion_share_fd_to_phys -
+* associate with a share fd
+* @client:	the client
+* @share_fd: passed from the user space
+* @addr point to the physical address
+* @size point to the size of this ion buffer
+*/
+
+int meson_ion_share_fd_to_phys(struct ion_client *client,
+	int share_fd, ion_phys_addr_t *addr, size_t *len);
+#endif


### PR DESCRIPTION
The Ion patch adds a new IOCTL that allows retrieving the physical address of the Ion buffer.  This is required for use with GE2D.

The GE2D patch corrects the canvas index for OSD0.  The width parameter is also corrected for destination planes.

The relevant upstream patches are:
https://github.com/LibreELEC/linux-amlogic/commit/d64924ee0a455b1ec8c693703417fe9c3497f6c1
https://github.com/LibreELEC/linux-amlogic/commit/3f4a724e2ce93686870cfc9707364824357debaa
