### PR TITLE
usb: ced1401: fix build errors

### DIFF
--- a/drivers/staging/ced1401/ced_ioctl.h
+++ b/drivers/staging/ced1401/ced_ioctl.h
@@ -17,6 +17,7 @@
 #define __CED_IOCTL_H__
 
 #include <linux/ioctl.h>
+#include "use1401.h"
 
 /* dma modes, only MODE_CHAR and MODE_LINEAR are used in this driver */
 #define MODE_CHAR		0

--- a/drivers/staging/ced1401/use1401.h
+++ b/drivers/staging/ced1401/use1401.h
@@ -9,6 +9,7 @@
 ****************************************************************************/
 #ifndef __USE1401_H__
 #define __USE1401_H__
+#define LINUX
 #include "machine.h"
 
 /*  Some definitions to make things compatible. If you want to use Use1401 directly */


### PR DESCRIPTION
The ced1401 driver won't build without -DLINUX or a #define statement
in the header.   The #define option is simpler and presumably there is no
intention to implement Windows support.

Signed-off-by: Alison Chaiken <alison@she-devel.com>