### PR TITLE
Fix 1280x1024 fbdev configuration (num_buffers variable)

### DIFF
--- a/drivers/gpu/drm/exynos/exynos_drm_fbdev.c
+++ b/drivers/gpu/drm/exynos/exynos_drm_fbdev.c
@@ -123,7 +123,7 @@ static int exynos_drm_fbdev_update(struct drm_fb_helper *helper,
 	unsigned int size = fb->width * fb->height * (fb->bits_per_pixel >> 3);
 	unsigned long offset;
 	
-	if(fb->width == 1024 || fb->width == 1280)
+	if(fb->width == 1024 || ((fb->width == 1280) && (fb->height == 720)))
 		num_buffers = 1;
 
 	drm_fb_helper_fill_fix(fbi, fb->pitches[0], fb->depth);
@@ -187,7 +187,6 @@ static int exynos_drm_fbdev_create(struct drm_fb_helper *helper,
 			sizes->surface_bpp);
 			
 	if((sizes->surface_width == 1024 && sizes->surface_height == 768) ||
-		(sizes->surface_width == 1280 && sizes->surface_height == 1024) ||
 		(sizes->surface_width == 1280 && sizes->surface_height == 720))
 		num_buffers = 1;
 

--- a/drivers/gpu/drm/exynos/exynos_drm_fbdev.c
+++ b/drivers/gpu/drm/exynos/exynos_drm_fbdev.c
@@ -187,6 +187,7 @@ static int exynos_drm_fbdev_create(struct drm_fb_helper *helper,
 			sizes->surface_bpp);
 			
 	if((sizes->surface_width == 1024 && sizes->surface_height == 768) ||
+		(sizes->surface_width == 1280 && sizes->surface_height == 1024) ||
 		(sizes->surface_width == 1280 && sizes->surface_height == 720))
 		num_buffers = 1;
 


### PR DESCRIPTION
Simple fix to have a fully working 1280x1024 fbdev (and not 1280x3072).