### PR TITLE
Enable per cpu thermal trips

### DIFF
--- a/arch/arm/boot/dts/exynos5422-odroidxu3-common.dtsi
+++ b/arch/arm/boot/dts/exynos5422-odroidxu3-common.dtsi
@@ -64,7 +64,7 @@
 		cooling-min-state = <0>;
 		cooling-max-state = <3>;
 		#cooling-cells = <2>;
-		cooling-levels = <0 150 190 252>;
+		cooling-levels = <0 110 170 230>;
 	};
 	
 	mali: mali@0x11800000 {
@@ -107,90 +107,28 @@
 		
 	thermal-zones {
 		cpu0_thermal: cpu0-thermal {
-			thermal-sensors = <&tmu_cpu0 0 &tmu_cpu1 0 &tmu_cpu2 0 &tmu_cpu3 0>;
-			polling-delay-passive = <250>;
-			polling-delay = <1000>;
-			trips {
-				cpu_alert0: cpu-alert-0 {
-					temperature = <70000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "passive";
-				};
-				cpu_alert1: cpu-alert-1 {
-					temperature = <75000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "passive";
-				};
-				cpu_alert2: cpu-alert-2 {
-					temperature = <80000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "passive";
-				};
-				cpu_alert3: cpu-alert-3 {
-					temperature = <90000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "passive";
-				};
-				cpu_alert4: cpu-alert-4 {
-					temperature = <95000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "passive";
-				};
-				cpu_alert5: cpu-alert-5 {
-					temperature = <103000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "passive";
-				};
-				cpu_alert6: cpu-alert-6 {
-					temperature = <110000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "passive";
-				};
-				cpu_criti0: cpu-crit-0 {
-					temperature = <115000>; /* millicelsius */
-					hysteresis = <10000>; /* millicelsius */
-					type = "critical";
-				};
-			};
-			cooling-maps {
-				map0 {
-					trip = <&cpu_alert0>;
-					cooling-device = <&fan0 0 1>;
-				};
-				map1 {
-					trip = <&cpu_alert1>;
-					cooling-device = <&fan0 1 2>;
-				};
-				map2 {
-					trip = <&cpu_alert2>;
-					cooling-device = <&fan0 2 3>;
-				};
-				/*
-				 * First trip for A7: 1000Mhz
-				 * First trip for A15: 1400Mhz
-				 */
-				map3 {
-					trip = <&cpu_alert3>;
-					cooling-device = <&cpu0 0 6>;
-				};
-				map4 {
-					trip = <&cpu_alert3>;
-					cooling-device = <&cpu4 0 3>;
-				};
-
-				/*
-				 * Second trip for A15: 600Mhz
-				 * Second trip for A7: 600Mhz
-				 */
-				map5 {
-					trip = <&cpu_alert4>;
-					cooling-device = <&cpu0 3 7>;
-				};
-				map6 {
-					trip = <&cpu_alert4>;
-					cooling-device = <&cpu4 3 14>;
-				};
-			};
+			thermal-sensors = <&tmu_cpu0 0>;
+			#define CPU_THERMAL_ZONE_NUM 0
+			#include "exynos5422-odroidxu3-trip-points.dtsi"
+			#undef CPU_THERMAL_ZONE_NUM
+		};
+		cpu1_thermal: cpu1-thermal {
+			thermal-sensors = <&tmu_cpu1 0>;
+			#define CPU_THERMAL_ZONE_NUM 1
+			#include "exynos5422-odroidxu3-trip-points.dtsi"
+			#undef CPU_THERMAL_ZONE_NUM
+		};
+		cpu2_thermal: cpu2-thermal {
+			thermal-sensors = <&tmu_cpu2 0>;
+			#define CPU_THERMAL_ZONE_NUM 2
+			#include "exynos5422-odroidxu3-trip-points.dtsi"
+			#undef CPU_THERMAL_ZONE_NUM
+		};
+		cpu3_thermal: cpu3-thermal {
+			thermal-sensors = <&tmu_cpu3 0>;
+			#define CPU_THERMAL_ZONE_NUM 3
+			#include "exynos5422-odroidxu3-trip-points.dtsi"
+			#undef CPU_THERMAL_ZONE_NUM
 		};
 	};
 };

--- a/arch/arm/boot/dts/exynos5422-odroidxu3-trip-points.dtsi
+++ b/arch/arm/boot/dts/exynos5422-odroidxu3-trip-points.dtsi
@@ -1,0 +1,100 @@
+/*
+ * Device tree sources for default OdroidXU3/Exynos5422 thermal zone definition
+ *
+ * Copyright (c) 2015 Lukasz Majewski <l.majewski@samsung.com>
+ *						Anand Moon <linux.amoon@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ */			
+
+#define _TOKENPASTE(x, y) x ## y
+#define TOKENPASTE(x, y) _TOKENPASTE(x, y)
+#define UNIQIFY(label) TOKENPASTE(label, CPU_THERMAL_ZONE_NUM)
+
+			polling-delay-passive = <250>;
+			polling-delay = <1000>;
+			trips {
+				UNIQIFY(cpu_alert0): cpu-alert-0 {
+					temperature = <70000>; /* millicelsius */
+					hysteresis = <10000>; /* millicelsius */
+					type = "active";
+				};
+				UNIQIFY(cpu_alert1): cpu-alert-1 {
+					temperature = <75000>; /* millicelsius */
+					hysteresis = <10000>; /* millicelsius */
+					type = "active";
+				};
+				UNIQIFY(cpu_alert2): cpu-alert-2 {
+					temperature = <80000>; /* millicelsius */
+					hysteresis = <10000>; /* millicelsius */
+					type = "active";
+				};
+				UNIQIFY(cpu_alert3): cpu-alert-3 {
+					temperature = <85000>; /* millicelsius */
+					hysteresis = <3000>; /* millicelsius */
+					type = "passive";
+				};
+				UNIQIFY(cpu_alert4): cpu-alert-4 {
+					temperature = <90000>; /* millicelsius */
+					hysteresis = <3000>; /* millicelsius */
+					type = "passive";
+				};
+				UNIQIFY(cpu_alert5): cpu-alert-5 {
+					temperature = <95000>; /* millicelsius */
+					hysteresis = <3000>; /* millicelsius */
+					type = "passive";
+				};
+				UNIQIFY(cpu_criti0): cpu-crit-0 {
+					temperature = <115000>; /* millicelsius */
+					hysteresis = <3000>; /* millicelsius */
+					type = "critical";
+				};
+			};
+			cooling-maps {
+				map0 {
+					trip = <&UNIQIFY(cpu_alert0)>;
+					cooling-device = <&fan0 0 1>;
+				};
+				map1 {
+					trip = <&UNIQIFY(cpu_alert1)>;
+					cooling-device = <&fan0 1 2>;
+				};
+				map2 {
+					trip = <&UNIQIFY(cpu_alert2)>;
+					cooling-device = <&fan0 2 3>;
+				};
+				/*
+				 * When reaching cpu_alert3, reduce A15 cores by 1 step.
+				 * The 2GHz step causes high thermals on multithreaded workloads
+				 * so better performance is gained by managing it out early.
+				 */
+				map3 {
+					trip = <&UNIQIFY(cpu_alert3)>;
+					cooling-device = <&cpu4 0 1>;
+				};
+				/*
+				* When reaching cpu_alert4, reduce A15 cores by 3 steps
+				* to further manage the performance level while keeping
+				* thermals under control.
+				*/
+				map4 {
+					trip = <&UNIQIFY(cpu_alert4)>;
+					cooling-device = <&cpu4 2 4>;
+				};
+				/*
+				 * When reaching cpu_alert5, reduce all CPUs to ensure thermal
+				 * safety. A7 cores don't produce much thermal load so they are
+				 * reduced less to optimise performance.
+				 */
+				map5 {
+					trip = <&UNIQIFY(cpu_alert5)>;
+					cooling-device = <&cpu0 0 2>;
+				};
+				map6 {
+					trip = <&UNIQIFY(cpu_alert5)>;
+					cooling-device = <&cpu4 5 14>;
+				};
+			};


### PR DESCRIPTION
Enables per cpu thermal trips without needing to duplicate the trips or cooling maps for each thermal zone by moving them into a separate file, then using the C preprocessor to generate the unique labels required for each thermal zone. This allows for easy expansion to other thermal zones as required with minimal work.

Patch also tweaks thermal trips slightly to better utilise cooling performance. A15's more progressively throttle to improve average clockspeed while keeping temps typically under 90C for active cooling with a heavy load. A7's are throttled later as their thermal contribution is low so keeping them clocked up improves efficiency on long workloads with their speed only reduced once thermals really require it to ensure thermal safety.