### PR TITLE
UBUNTU: SAUCE: (no-up) add compat_uts_machine= kernel command line override

### DIFF
--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1083,6 +1083,21 @@ out:
 DECLARE_RWSEM(uts_sem);
 
 #ifdef COMPAT_UTS_MACHINE
+static char compat_uts_machine[__OLD_UTS_LEN+1] = COMPAT_UTS_MACHINE;
+
+static int __init parse_compat_uts_machine(char *arg)
+{
+	strncpy(compat_uts_machine, arg, __OLD_UTS_LEN);
+	compat_uts_machine[__OLD_UTS_LEN] = 0;
+	return 0;
+}
+early_param("compat_uts_machine", parse_compat_uts_machine);
+
+#undef COMPAT_UTS_MACHINE
+#define COMPAT_UTS_MACHINE compat_uts_machine
+#endif
+
+#ifdef COMPAT_UTS_MACHINE
 #define override_architecture(name) \
 	(personality(current->personality) == PER_LINUX32 && \
 	 copy_to_user(name->machine, COMPAT_UTS_MACHINE, \


### PR DESCRIPTION
I have the same problem that they have, I want to use my odroid-c2 as a build server to build armv7l artifacts.

> BugLink: http://bugs.launchpad.net/bugs/1520627
>
> We wish to use the arm64 buildds to build armhf binaries in 32bit chroots.
To make this work we need uname to return armv7l machine type.  To achieve
this add a kernel command line override for the 32bit machine type.
Add compat_uts_machine=<type> to allow the LINUX32 personality to return
that type for uname.