### PR TITLE
Enable proper CPU voltage curve to improve thermal throttling

### DIFF
--- a/arch/arm/boot/dts/exynos5800.dtsi
+++ b/arch/arm/boot/dts/exynos5800.dtsi
@@ -35,13 +35,13 @@
 		clock-latency-ns = <140000>;
 	};
 	opp@1800000000 {
-		opp-microvolt = <1312500>;
+		opp-microvolt = <1200000>;
 	};
 	opp@1700000000 {
-		opp-microvolt = <1312500>;
+		opp-microvolt = <1162500>;
 	};
 	opp@1600000000 {
-		opp-microvolt = <1312500>;
+		opp-microvolt = <1125000>;
 	};
 	opp@1500000000 {
 		opp-microvolt = <1087500>;
@@ -53,7 +53,7 @@
 		opp-microvolt = <1050000>;
 	};
 	opp@1200000000 {
-		opp-microvolt = <1050000>;
+		opp-microvolt = <1025000>;
 	};
 	opp@1100000000 {
 		opp-microvolt = <1000000>;


### PR DESCRIPTION
This corrects the A15 CPU voltage curve at high frequencies. The opp table is using ASV group 0 voltages except at a few select points where the voltage is much higher which hurts the thermal driver as power/heat is kept unnecessarily high in the 1.6-1.8GHz range due to the lack of a voltage curve across those frequencies. This moves the 4 outlying opp points inline with the ASV 0 curve that is used for every other opp point.

Overall performance improves by approx. 10% on a heavy multi-threaded load and it also leads to lower fan usage at low to moderate load levels.