### PR TITLE
Added a stub ndo_poll_controller to support netconsole - idea from ht…

### DIFF
--- a/drivers/net/usb/smsc95xx.c
+++ b/drivers/net/usb/smsc95xx.c
@@ -87,6 +87,10 @@ static char *macaddr = ":";
 module_param(macaddr, charp, 0);
 MODULE_PARM_DESC(macaddr, "MAC address");
 
+static void smsc95xx_netconsole(struct net_device *netdev)
+{
+}
+
 static int __must_check __smsc95xx_read_reg(struct usbnet *dev, u32 index,
 					    u32 *data, int in_pm)
 {
@@ -1309,6 +1313,7 @@ static const struct net_device_ops smsc95xx_netdev_ops = {
 	.ndo_do_ioctl 		= smsc95xx_ioctl,
 	.ndo_set_rx_mode	= smsc95xx_set_multicast,
 	.ndo_set_features	= smsc95xx_set_features,
+        .ndo_poll_controller    = smsc95xx_netconsole,
 };
 
 static int smsc95xx_bind(struct usbnet *dev, struct usb_interface *intf)


### PR DESCRIPTION
Idea from https://forum.odroid.com/viewtopic.php?f=82&t=5077

Without this patch, netconsole can't be enabled:
```
[  187.646648] netpoll: netconsole: local IPv4 address 192.168.228.3
[  187.646671] netpoll: netconsole: interface 'eth0'
[  187.646695] netpoll: netconsole: remote port 6666
[  187.646721] netpoll: netconsole: remote IPv4 address 192.168.228.1
[  187.646745] netpoll: netconsole: remote ethernet address 44:8a:5b:56:37:5a
[  187.646908] netpoll: netconsole: eth0 doesn't support polling, aborting
[  187.652320] netconsole: cleaning up
```

With the patch, netconsole works fine for XU3/4:
```
[  184.303266] netpoll: netconsole: local port 6666
[  184.303293] netpoll: netconsole: local IPv4 address 192.168.228.3
[  184.303310] netpoll: netconsole: interface 'eth0'
[  184.303326] netpoll: netconsole: remote port 6666
[  184.303344] netpoll: netconsole: remote IPv4 address 192.168.228.1
[  184.303364] netpoll: netconsole: remote ethernet address 44:8a:5b:56:37:5a
[  184.303705] console [netcon0] enabled
[  184.303719] netconsole: network logging started
```
I've also left an iperf test running for a night and had no adverse network performance/issues.