### PR TITLE
Add fake polling support for XU4 to enable netconsole

### DIFF
--- a/drivers/net/usb/r8152.c
+++ b/drivers/net/usb/r8152.c
@@ -7070,6 +7070,10 @@ static int rtl8152_change_mtu(struct net_device *dev, int new_mtu)
 	return ret;
 }
 
+static void rtl8152_netconsole(struct net_device *netdev)
+{
+}
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29)
 static const struct net_device_ops rtl8152_netdev_ops = {
 	.ndo_open		= rtl8152_open,
@@ -7086,6 +7090,7 @@ static const struct net_device_ops rtl8152_netdev_ops = {
 	.ndo_set_mac_address	= rtl8152_set_mac_address,
 	.ndo_change_mtu		= rtl8152_change_mtu,
 	.ndo_validate_addr	= eth_validate_addr,
+	.ndo_poll_controller    = rtl8152_netconsole,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,4)
 	.ndo_features_check	= rtl8152_features_check,
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,18,4) */


### PR DESCRIPTION
Now netconsole support can be enabled on XU4 as well. It's the same trick used as for XU3, but applied on the r8152 driver: https://github.com/hardkernel/linux/pull/295