### PR TITLE
Backport gcc-7 compilation fix from mainline linux tree

### DIFF
--- a/include/linux/log2.h
+++ b/include/linux/log2.h
@@ -16,12 +16,6 @@
 #include <linux/bitops.h>
 
 /*
- * deal with unrepresentable constant logarithms
- */
-extern __attribute__((const, noreturn))
-int ____ilog2_NaN(void);
-
-/*
  * non-constant log of base 2 calculators
  * - the arch may override these in asm/bitops.h if they can be implemented
  *   more efficiently than using fls() and fls64()
@@ -85,7 +79,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
 #define ilog2(n)				\
 (						\
 	__builtin_constant_p(n) ? (		\
-		(n) < 1 ? ____ilog2_NaN() :	\
+		(n) < 2 ? 0 :			\
 		(n) & (1ULL << 63) ? 63 :	\
 		(n) & (1ULL << 62) ? 62 :	\
 		(n) & (1ULL << 61) ? 61 :	\
@@ -148,10 +142,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
 		(n) & (1ULL <<  4) ?  4 :	\
 		(n) & (1ULL <<  3) ?  3 :	\
 		(n) & (1ULL <<  2) ?  2 :	\
-		(n) & (1ULL <<  1) ?  1 :	\
-		(n) & (1ULL <<  0) ?  0 :	\
-		____ilog2_NaN()			\
-				   ) :		\
+		1 ) :				\
 	(sizeof(n) <= 4) ?			\
 	__ilog2_u32(n) :			\
 	__ilog2_u64(n)				\


### PR DESCRIPTION
Original commit: 474c90156c8dcc2fa815e6716cc9394d7930cb9c
Author: Linus Torvalds <torvalds@linux-foundation.org>
Summary: give up on gcc ilog2() constant optimizations

This fixes build issue with gcc-7.

How failure looks: https://sourceforge.net/p/aufs/mailman/message/35865397/
Issue in kernel bugzilla: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72785
Link to commit addressing it in mainline: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=474c90156c8dcc2fa815e6716cc9394d7930cb9c