### PR TITLE
Add fake netpoll support in order to enable netconsole

### DIFF
--- a/drivers/amlogic/ethernet/am_net8218.c
+++ b/drivers/amlogic/ethernet/am_net8218.c
@@ -1455,6 +1455,10 @@ static int set_mac_addr_n(struct net_device *dev, void *addr){
 	return 0;
 }
 
+static void fake_netpoll(struct net_device *netdev){
+
+}
+
 static const struct net_device_ops am_netdev_ops = {
 	.ndo_open               = netdev_open,
 	.ndo_stop               = netdev_close,
@@ -1466,6 +1470,7 @@ static const struct net_device_ops am_netdev_ops = {
 	.ndo_change_mtu         = eth_change_mtu,
 	.ndo_set_mac_address    = set_mac_addr_n,
 	.ndo_validate_addr      = eth_validate_addr,
+	.ndo_poll_controller	= fake_netpoll,
 };
 
 static int aml_ethtool_get_settings(struct net_device *dev,


### PR DESCRIPTION
I was unable to test the changes because my compiled kernel failed to load the root filesystem (don't know why), but it *should* work. Please test that after applying the patch the kernel still boots!