### PR TITLE
Missing ifdef causing compilation issue.  Fixed

### DIFF
--- a/drivers/amlogic/ethernet/am_net8218.c
+++ b/drivers/amlogic/ethernet/am_net8218.c
@@ -1470,7 +1470,9 @@ static const struct net_device_ops am_netdev_ops = {
 	.ndo_change_mtu         = eth_change_mtu,
 	.ndo_set_mac_address    = set_mac_addr_n,
 	.ndo_validate_addr      = eth_validate_addr,
+#ifdef CONFIG_NET_POLL_CONTROLLER
 	.ndo_poll_controller	= fake_netpoll,
+#endif
 };
 
 static int aml_ethtool_get_settings(struct net_device *dev,


### PR DESCRIPTION
Compilation throw error:
```
drivers/amlogic/ethernet/am_net8218.c:1473:2: error: unknown field 'ndo_poll_controller' specified in initializer
  .ndo_poll_controller = fake_netpoll,
  ^
drivers/amlogic/ethernet/am_net8218.c:1473:25: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
  .ndo_poll_controller = fake_netpoll,
                         ^~~~~~~~~~~~
drivers/amlogic/ethernet/am_net8218.c:1473:25: note: (near initialization for 'am_netdev_ops.ndo_do_ioctl')
```

This declaration depends on CONFIG_NET_POOL_CONTROLLER, the `#ifdef` solves the compilation issue.