### PR TITLE
Change DMA coherent pool size to 2MB

### DIFF
--- a/arch/arm64/mm/dma-mapping.c
+++ b/arch/arm64/mm/dma-mapping.c
@@ -32,7 +32,7 @@
 
 static struct gen_pool *atomic_pool;
 
-#define DEFAULT_DMA_COHERENT_POOL_SIZE  SZ_256K
+#define DEFAULT_DMA_COHERENT_POOL_SIZE  SZ_2M
 static size_t atomic_pool_size __initdata = DEFAULT_DMA_COHERENT_POOL_SIZE;
 
 static int __init early_coherent_pool(char *p)


### PR DESCRIPTION
Resolves several issues around UAS, crappy RAID0 performance included: https://forum.armbian.com/topic/6496-odroid-n1-not-a-review-yet/?page=2&tab=comments#comment-50108