### PR TITLE
arm64: dts: Improve vdd_cpu_b regulator ramp delay

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-odroidn1-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-odroidn1-linux.dts
@@ -409,7 +409,7 @@
 		regulator-name = "vdd_cpu_b";
 		regulator-min-microvolt = <712500>;
 		regulator-max-microvolt = <1500000>;
-		regulator-ramp-delay = <1000>;
+		regulator-ramp-delay = <40000>;
 		vsel-gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
 		fcs,suspend-voltage-selector = <1>;
 		regulator-always-on;


### PR DESCRIPTION
Increases the regulator ramp delay divider to reduce CPU transition latencies on DVFS changes.

Notes and testing here: https://forum.odroid.com/viewtopic.php?f=154&t=30303&view=unread#p217262