### PR TITLE
ODROID-N1: VOP - Don't dereference null pointers.

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
@@ -61,7 +61,7 @@
 		VOP_REG_SUPPORT(vop, win->phy->name)
 
 #define VOP_WIN_SCL_EXT_SUPPORT(vop, win, name) \
-		(win->phy->scl->ext && \
+		(win && win->phy && win->phy->scl && win->phy->scl->ext && \
 		VOP_REG_SUPPORT(vop, win->phy->scl->ext->name))
 
 #define VOP_CTRL_SUPPORT(vop, name) \


### PR DESCRIPTION
Fixes:
    [ 2227.011089] Unable to handle kernel NULL pointer dereference at virtual address 00000000
    [ 2227.019221] pgd = ffffffc0edcf1000
    [ 2227.022675] [00000000] *pgd=0000000000000000, *pud=0000000000000000
    [ 2227.029027] Internal error: Oops: 96000005 [#1] SMP
    [ 2227.033903] Modules linked in: af_packet nls_cp936 vfat fat rock_gpiomem autofs4
    [ 2227.041404] CPU: 1 PID: 1834 Comm: Xorg Not tainted 4.4.112 #2
    [ 2227.047232] Hardware name: Hardkernel ODROID-N1 (DT)
    [ 2227.052194] task: ffffffc0d29e3400 task.stack: ffffffc0d2984000
    [ 2227.058116] PC is at vop_crtc_bandwidth+0x1f8/0x2dc
    [ 2227.062992] LR is at vop_crtc_bandwidth+0xe4/0x2dc