### PR TITLE
Correct cooling device maps for odroid xu3/4

### DIFF
--- a/arch/arm/boot/dts/exynos5422-odroidxu3-trip-points.dtsi
+++ b/arch/arm/boot/dts/exynos5422-odroidxu3-trip-points.dtsi
@@ -82,7 +82,7 @@
 				*/
 				map4 {
 					trip = <&UNIQIFY(cpu_alert4)>;
-					cooling-device = <&cpu4 2 8>;
+					cooling-device = <&cpu4 4 8>;
 				};
 				/*
 				 * When reaching cpu_alert5, reduce all CPUs to ensure thermal
@@ -95,6 +95,6 @@
 				};
 				map6 {
 					trip = <&UNIQIFY(cpu_alert5)>;
-					cooling-device = <&cpu4 5 14>;
+					cooling-device = <&cpu4 8 14>;
 				};
 			};


### PR DESCRIPTION
There is a small issue in the thermal throttling where the higher trip points allow for a higher clockspeed than the lower trip, meaning as the SoC temps increase the device is allowed to initially increase it's clockspeed incorrectly.

This change ensures clockspeeds can only decrease as SoC temperature is increasing.