### PR TITLE
net: phy: rtl8211f disable eee led indication

### DIFF
--- a/drivers/net/phy/realtek.c
+++ b/drivers/net/phy/realtek.c
@@ -26,6 +26,7 @@
 #include <linux/amlogic/pm.h>
 #endif
 #define RTL821x_LCR		0x10
+#define RTL821x_EEELCR		0x11
 #define RTL821x_PHYSR		0x11
 #define RTL821x_PHYSR_DUPLEX	0x2000
 #define RTL821x_PHYSR_SPEED	0xc000
@@ -152,6 +153,7 @@ static int rtl8211f_config_init(struct phy_device *phydev)
 #endif
 	phy_write(phydev, RTL8211F_PAGE_SELECT, 0xd04); /*set page 0xd04*/
 	phy_write(phydev, RTL821x_LCR, 0XC171); /*led configuration*/
+	phy_write(phydev, RTL821x_EEELCR, 0); /*disable eee led indication*/
 
 	/* restore to default page 0 */
 	phy_write(phydev, RTL8211F_PAGE_SELECT, 0x0);


### PR DESCRIPTION
This PR disables the "Energy Efficient Ethernet" (EEE) indication by the Ethernet port LEDs.
EEE indication is on by default, and when the device is connected to certain switches the LEDs blink in an unusual pattern.
More info on the issue: https://forum.odroid.com/viewtopic.php?f=181&t=33935