### PR TITLE
CEC: AOCEC libcec support

### DIFF
--- a/drivers/amlogic/cec/hdmi_ao_cec.c
+++ b/drivers/amlogic/cec/hdmi_ao_cec.c
@@ -65,7 +65,7 @@ static struct early_suspend aocec_suspend_handler;
 
 
 #define CEC_FRAME_DELAY		msecs_to_jiffies(400)
-#define CEC_DEV_NAME		"cec"
+#define CEC_DEV_NAME		"aocec"
 
 #define CEC_POWER_ON		(0 << 0)
 #define CEC_EARLY_SUSPEND	(1 << 0)
@@ -1905,7 +1905,8 @@ static void cec_task(struct work_struct *work)
 	cec_cfg = cec_config(0, 0);
 	if (cec_cfg & CEC_FUNC_CFG_CEC_ON) {
 		/*cec module on*/
-		if (cec_dev && (!wake_ok || cec_service_suspended()))
+		if (cec_dev && (!wake_ok || cec_service_suspended())
+			&& !(cec_dev->hal_flag & (1 << HDMI_OPTION_SYSTEM_CEC_CONTROL)))
 			cec_rx_process();
 
 		/*for check rx buffer for old chip version, cec rx irq process*/
@@ -2530,6 +2531,11 @@ static ssize_t hdmitx_cec_write(struct file *f, const char __user *buf,
 	if (cec_cfg & CEC_FUNC_CFG_CEC_ON) {
 		/*cec module on*/
 		ret = cec_ll_tx(tempbuf, size);
+		if (ret == CEC_FAIL_NACK) {
+			return -1;
+		} else {
+			return size;
+		}
 	} else {
 		CEC_ERR("err:cec module disabled\n");
 	}
@@ -2906,9 +2912,7 @@ static char *aml_cec_class_devnode(struct device *dev, umode_t *mode)
 {
 	if (mode) {
 		*mode = 0666;
-		CEC_INFO("mode is %x\n", *mode);
-	} else
-		CEC_INFO("mode is null\n");
+	}
 	return NULL;
 }
 

--- a/drivers/amlogic/cec/hdmi_ao_cec.h
+++ b/drivers/amlogic/cec/hdmi_ao_cec.h
@@ -22,7 +22,7 @@
 #define CEC_DRIVER_VERSION	"Ver 2018/11/21\n"
 
 #define CEC_FRAME_DELAY		msecs_to_jiffies(400)
-#define CEC_DEV_NAME		"cec"
+#define CEC_DEV_NAME		"aocec"
 
 #define CEC_EARLY_SUSPEND	(1 << 0)
 #define CEC_DEEP_SUSPEND	(1 << 1)


### PR DESCRIPTION
This PR makes CEC work with the existing LibCEC AOCEC Adapter. It is basically a short port from the work me and @gdachs did for the 3.14 Kernel. I have not bothered to bring back the legacy CEC input mode which some users like. I'm not sure it's worth it but if I do I will make a seperate PR.

Here are the changes explained.

* Renaming the devnode because /dev/cec was a bit ambiguous in LibCEC so we made it a little bit more amlogic specific.
* Disable kernel cec processing when libcec is used in cec_task
* Return values were fixed to correspond to what libcec expects.
* Removed CEC_INFO print that is spamming kernel log

Tested on Odroid N2 with CoreELEC on Samsung FHD TV and on LG OLED. Works as expected.
I know that HK is using a udev rule in ubuntu to symlink the devnode to /dev/aocec so let me know if you want me to drop this change and rebase.


Thanks
