### PR TITLE
Update exynos5422-odroid-core.dtsi

### DIFF
--- a/arch/arm/boot/dts/exynos5422-odroid-core.dtsi
+++ b/arch/arm/boot/dts/exynos5422-odroid-core.dtsi
@@ -161,6 +161,7 @@
 				regulator-name = "vddq_mmc0";
 				regulator-min-microvolt = <1800000>;
 				regulator-max-microvolt = <1800000>;
+				regulator-always-on;
 			};
 
 			ldo4_reg: LDO4 {


### PR DESCRIPTION
Added the regulator-always-on attribute to LDO3 / vddq_mmc0. This keeps the SD card powered after a shutdown or reboot giving the board sufficient time to finish the operation.