### PR TITLE
ALSA: usb-audio: Add Gustard U16/X26 to quirks for native DSD support

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1217,6 +1217,7 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	case USB_ID(0x20b1, 0x2008): /* Matrix Audio X-Sabre */
 	case USB_ID(0x20b1, 0x300a): /* Matrix Audio Mini-i Pro */
 	case USB_ID(0x22d9, 0x0416): /* OPPO HA-1 */
+	case USB_ID(0x292b, 0xc4b3): /* Gustard U16/X26 USB Interface */
 		if (fp->altsetting == 2)
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 		break;


### PR DESCRIPTION
ALSA: usb-audio: Add Gustard U16/X26 to quirks for native DSD support