### PR TITLE
Add unique UUID to odroid-joypads

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux-v11.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux-v11.dts
@@ -22,6 +22,11 @@
 
 	joypad: odroidgo2-joypad {
                 compatible = "odroidgo2-joypad";
+                
+                joypad-name = "odroidgo2_joypad_v11";
+                joypad-product = <0x0002>;
+                joypad-revision = <0x0011>;
+				
                 /*
                   - odroidgo2-joypad sysfs list -
 		   * for poll device interval(ms)

--- a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux.dts
@@ -22,6 +22,11 @@
 
 	joypad: odroidgo2-joypad {
                 compatible = "odroidgo2-joypad";
+                
+                joypad-name = "odroidgo2_joypad";
+                joypad-product = <0x0001>;
+                joypad-revision = <0x0101>;
+				
                 /*
                   - odroidgo2-joypad sysfs list -
 		   * for poll device interval(ms)

--- a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo3-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo3-linux.dts
@@ -39,6 +39,11 @@
 
 	joypad: odroidgo3-joypad {
                 compatible = "odroidgo3-joypad";
+                
+                joypad-name = "odroidgo3_joypad";
+                joypad-product = <0x0003>;
+                joypad-revision = <0x0111>;
+               
 		status = "okay";
                 /*
                   - odroidgo3-joypad sysfs list -

--- a/drivers/input/joystick/odroidgo2-joypad.c
+++ b/drivers/input/joystick/odroidgo2-joypad.c
@@ -646,6 +646,8 @@ static int joypad_input_setup(struct device *dev, struct joypad *joypad)
 	struct input_polled_dev *poll_dev;
 	struct input_dev *input;
 	int nbtn, error;
+	u32 joypad_revision = 0;
+	u32 joypad_product = 0;
 
 	poll_dev = devm_input_allocate_polled_device(dev);
 	if (!poll_dev) {
@@ -661,13 +663,15 @@ static int joypad_input_setup(struct device *dev, struct joypad *joypad)
 
 	input = poll_dev->input;
 
-	input->name = DRV_NAME;
+	device_property_read_string(dev, "joypad-name", &input->name);
 	input->phys = DRV_NAME"/input0";
 
+	device_property_read_u32(dev, "joypad-revision", &joypad_revision);
+	device_property_read_u32(dev, "joypad-product", &joypad_product);
 	input->id.bustype = BUS_HOST;
 	input->id.vendor  = 0x0001;
-	input->id.product = 0x0001;
-	input->id.version = 0x0101;
+	input->id.product = (u16)joypad_product;
+	input->id.version = (u16)joypad_revision;
 
 	/* IIO ADC key setup (0 mv ~ 1800 mv) * adc->scale */
 	__set_bit(EV_ABS, input->evbit);

--- a/drivers/input/joystick/odroidgo3-joypad.c
+++ b/drivers/input/joystick/odroidgo3-joypad.c
@@ -860,6 +860,8 @@ static int joypad_input_setup(struct device *dev, struct joypad *joypad)
 	struct input_polled_dev *poll_dev;
 	struct input_dev *input;
 	int nbtn, error;
+	u32 joypad_revision = 0;
+	u32 joypad_product = 0;
 
 	poll_dev = devm_input_allocate_polled_device(dev);
 	if (!poll_dev) {
@@ -875,13 +877,15 @@ static int joypad_input_setup(struct device *dev, struct joypad *joypad)
 
 	input = poll_dev->input;
 
-	input->name = DRV_NAME;
+	device_property_read_string(dev, "joypad-name", &input->name);
 	input->phys = DRV_NAME"/input0";
 
+	device_property_read_u32(dev, "joypad-revision", &joypad_revision);
+	device_property_read_u32(dev, "joypad-product", &joypad_product);
 	input->id.bustype = BUS_HOST;
 	input->id.vendor  = 0x0001;
-	input->id.product = 0x0001;
-	input->id.version = 0x0101;
+	input->id.product = (u16)joypad_product;
+	input->id.version = (u16)joypad_revision;
 
 	/* IIO ADC key setup (0 mv ~ 1800 mv) * adc->scale */
 	__set_bit(EV_ABS, input->evbit);


### PR DESCRIPTION
This adds unique UUIDs to the Odroid-joypads

Original patch by @valadaa48, modified for the Odroid-go super