### PR TITLE
Odroid-GO3: Fix a typo in dts file

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3326-odroidgo3-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3326-odroidgo3-linux.dts
@@ -404,7 +404,7 @@
 			  15 : MIPI_DSI_SHORT_WRITE_PARAM
 			  39 : MIPI_DSI_LONG_WRITE
 
-			- ST7710S (Initialize sequence) -
+			- ST7701S (Initialize sequence) -
 			  01: Soft reset
 			  11: Sleep out & 250ms wait
 			  FF: Bank select CMD


### PR DESCRIPTION
The panel controller appears to be ST7701S, not ST7710S.
