### PR TITLE
Odroid 6.6.y: Small XU3/4 Improvements

### DIFF
--- a/arch/arm/boot/dts/samsung/exynos5422-odroidxu3.dts
+++ b/arch/arm/boot/dts/samsung/exynos5422-odroidxu3.dts
@@ -72,7 +72,7 @@
 };
 
 &usbdrd_dwc3_1 {
-	dr_mode = "peripheral";
+	dr_mode = "host";
 };
 
 &usbhost2 {


### PR DESCRIPTION
- Proper reset the Ethernet controller
- Enable second USB3 port on ODroid XU3