### PR TITLE
drm/rockchip: dw-hdmi: default HDMI output to RGB instead of auto YCbCr444

### DIFF
--- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
@@ -2651,6 +2651,27 @@ dw_hdmi_rockchip_attach_properties(struct drm_connector *connector,
 	struct rockchip_drm_private *private = connector->dev->dev_private;
 	int ret;
 
+	/*
+	 * Default the HDMI output to RGB.
+	 *
+	 * The Rockchip BSP auto-selects YCbCr444 whenever the sink EDID
+	 * advertises YCbCr444 support. For PC monitors (e.g. HP E27u G4)
+	 * this makes VOP2 enable RGB->YCbCr conversion (r2y_en=1,
+	 * bus_format=YUV8_1X24) while the HDMI link/monitor still expects
+	 * RGB, producing a green-tinted screen. Mainline (and the dw-hdmi
+	 * core, i915, etc.) default to RGB; only fall back to YCbCr for
+	 * bandwidth reasons. Map the auto-selected YCbCr444 formats back to
+	 * the equivalent RGB format here (preserving color depth).
+	 *
+	 * High-bandwidth modes (e.g. 4K@60 on a TV) still fall back to
+	 * YCbCr420 in dw_hdmi_rockchip_select_output(), and userspace can
+	 * force a format via the 'color_format' connector property.
+	 */
+	if (color == MEDIA_BUS_FMT_YUV8_1X24)
+		color = MEDIA_BUS_FMT_RGB888_1X24;
+	else if (color == MEDIA_BUS_FMT_YUV10_1X30)
+		color = MEDIA_BUS_FMT_RGB101010_1X30;
+
 	switch (color) {
 	case MEDIA_BUS_FMT_RGB101010_1X30:
 		hdmi->hdmi_output = RK_IF_FORMAT_RGB;


### PR DESCRIPTION
## 문제

ODROID-M1 (RK3568) + Ubuntu 22.04 BSP 커널(5.10.0-odroid-arm64)에서, HDMI 모니터(HP E27u G4)가 로그인 후 **녹색 화면**으로 출력됨. VU8M(DSI)은 정상. GDM 로그인 화면까지는 정상이고, 사용자 세션 진입 후 녹색으로 깨짐.

## 원인

`dw_hdmi_rockchip_attach_properties()`가 sink EDID에 YCbCr444 지원이 광고되면 무조건 `RK_IF_FORMAT_YCBCR444`를 선택함. PC 모니터의 경우:

- VOP2가 RGB→YCbCr 변환을 활성화 (`r2y_en=1`, `bus_format=YUV8_1X24`)
- 그러나 HDMI 링크/모니터는 RGB를 기대 → 색 포맷 불일치 → 녹색 화면

같은 모니터가 Intel(i915), mainline 커널에서는 RGB로 정상 출력됨. mainline rockchip dw-hdmi는 색 포맷 자동선택 로직이 없고 dw-hdmi core 기본값(RGB)을 따름.

debugfs(`/sys/kernel/debug/dri/0/`) 레지스터로 확인:

| | VP0 (HDMI, 녹색) | VP1 (DSI, 정상) |
|---|---|---|
| bus_format | `YUV8_1X24` | `RGB888_1X24` |
| overlay_mode | `1` | `0` |
| win CSC | `r2y_en=1` | `r2y_en=0` |

connector property `color_format` = `ycbcr444(1)`.

## 수정

`attach_properties()`에서 자동 선택된 YCbCr444 포맷(`YUV8_1X24` / `YUV10_1X30`)을 동등한 RGB 포맷으로 매핑. color depth는 보존.

- 고대역폭 모드(4K@60 등)는 `dw_hdmi_rockchip_select_output()`의 기존 YCbCr420 fallback이 그대로 처리
- 사용자는 `color_format` connector property로 명시적 YCbCr 선택 가능 (TV 등)

## 테스트

ODROID-M1 + HP E27u G4(HDMI) + VU8M(DSI), gcc 14.2 크로스컴파일:

- `color_format` property가 `ycbcr444(1)` → `rgb(0)`으로 전환 확인
- VOP2가 R2Y 변환을 더 이상 활성화하지 않음 → **녹색 원인 제거 확인**

> **주의 (draft 사유):** 이 패치는 색 포맷(녹색) 문제를 해결합니다. 다만 패치 적용 후 별도의 HDMI 출력/모드셋 이슈(검정 화면)가 남아있어 조사 중이며, 본 색 포맷 수정과는 무관한 별개 레이어 문제로 보입니다. 듀얼 디스플레이(HDMI+DSI) 동시 출력 검증이 끝나면 draft를 해제할 예정입니다.
